### PR TITLE
Changing repository links and removing scientific dependency for yesod compatibility

### DIFF
--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -7,8 +7,8 @@ description:
     functions for handling BIP32 extended keys, functions for building and
     signing various types of regular and multisig transactions and a definition
     of the network protocol messages.
-homepage:              http://github.com/plaprade/haskoin
-bug-reports:           http://github.com/plaprade/haskoin/issues
+homepage:              http://github.com/haskoin/haskoin
+bug-reports:           http://github.com/haskoin/haskoin/issues
 stability:             experimental
 license:               PublicDomain
 license-file:          UNLICENSE
@@ -21,7 +21,7 @@ extra-source-files:    tests/data/*.json
 
 source-repository head
     type:     git
-    location: git://github.com/plaprade/haskoin.git
+    location: git://github.com/haskoin/haskoin.git
 
 
 library
@@ -86,7 +86,6 @@ library
                        either               >= 4.0  && < 4.1,
                        mtl                  >= 2.1  && < 2.2, 
                        pbkdf                >= 1.1  && < 1.2,
-                       scientific           >= 0.2  && < 0.3,
                        split                >= 0.2  && < 0.3,
                        text                 >= 0.11 && < 0.12,
                        text-icu             >= 0.6  && < 0.7,
@@ -137,7 +136,6 @@ test-suite test-haskoin
                        either                     >= 4.0  && < 4.1,
                        mtl                        >= 2.1  && < 2.2, 
                        pbkdf                      >= 1.1  && < 1.2,
-                       scientific                 >= 0.2  && < 0.3,
                        split                      >= 0.2  && < 0.3,
                        text                       >= 0.11 && < 0.12,
                        text-icu                   >= 0.6  && < 0.7,


### PR DESCRIPTION
ACK. We need to look at the aeson dependency and probably bump it to make it compatible with hackage next time we release. The new version of aeson has a dependency >= 0.3 on scientific.
