### PR TITLE
Adding the Reject message to the protocol types

### DIFF
--- a/Network/Haskoin/Protocol.hs
+++ b/Network/Haskoin/Protocol.hs
@@ -55,6 +55,9 @@ module Network.Haskoin.Protocol
 , Ping(..)
 , Pong(..)
 , Alert(..)
+, Reject(..)
+, RejectCode(..)
+, reject
 
   -- *Messages
 , Message(..)

--- a/tests/Network/Haskoin/Protocol/Arbitrary.hs
+++ b/tests/Network/Haskoin/Protocol/Arbitrary.hs
@@ -54,6 +54,20 @@ instance Arbitrary Addr where
 instance Arbitrary Alert where
     arbitrary = Alert <$> arbitrary <*> arbitrary
 
+instance Arbitrary Reject where
+    arbitrary = Reject <$> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary RejectCode where
+    arbitrary = elements [ RejectMalformed
+                         , RejectInvalid
+                         , RejectInvalid
+                         , RejectDuplicate
+                         , RejectNonStandard
+                         , RejectDust
+                         , RejectInsufficientFee
+                         , RejectCheckpoint
+                         ]
+
 instance Arbitrary BlockHeader where
     arbitrary = BlockHeader <$> arbitrary
                             <*> (hash256 <$> arbitrary)

--- a/tests/Network/Haskoin/Protocol/Tests.hs
+++ b/tests/Network/Haskoin/Protocol/Tests.hs
@@ -24,6 +24,7 @@ tests =
         , testProperty "Version" (metaGetPut :: Version -> Bool)
         , testProperty "Addr" (metaGetPut :: Addr -> Bool)
         , testProperty "Alert" (metaGetPut :: Alert -> Bool)
+        , testProperty "Reject" (metaGetPut :: Reject -> Bool)
         , testProperty "TxIn" (metaGetPut :: TxIn -> Bool)
         , testProperty "TxOut" (metaGetPut :: TxOut -> Bool)
         , testProperty "OutPoint" (metaGetPut :: OutPoint -> Bool)


### PR DESCRIPTION
The Reject type is sent to a remote peer if the local peer rejected a message for some reason. The reason and a code is sent inside that reject message. I had to move MessageCommand from Message.hs to Types.hs as the new Reject type uses it (and Message.hs imports Types.hs). 
