### PR TITLE
Adding separate types TxHash and BlockHash

### DIFF
--- a/Network/Haskoin/Crypto.hs
+++ b/Network/Haskoin/Crypto.hs
@@ -59,10 +59,14 @@ module Network.Haskoin.Crypto
 , Word128
 
   -- *Hash functions
-, Hash512
-, Hash256
-, Hash160
+, TxHash
+, BlockHash
 , CheckSum32
+, txHash
+, cbHash
+, headerHash
+, encodeTxHashLE
+, decodeTxHashLE
 , hash512
 , hash512BS
 , hash256

--- a/Network/Haskoin/Crypto/Base58.hs
+++ b/Network/Haskoin/Crypto/Base58.hs
@@ -28,7 +28,8 @@ import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 
-import Network.Haskoin.Crypto.Hash 
+import Network.Haskoin.Crypto.BigWord
+import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Util 
 
 b58String :: String
@@ -101,9 +102,9 @@ decodeBase58Check bs = do
 -- |Data type representing a Bitcoin address
 data Address 
     -- | Public Key Hash Address
-    = PubKeyAddress { getAddrHash :: Hash160 }
+    = PubKeyAddress { getAddrHash :: Word160 }
     -- | Script Hash Address
-    | ScriptAddress { getAddrHash :: Hash160 }
+    | ScriptAddress { getAddrHash :: Word160 }
        deriving (Eq, Show, Read)
 
 instance NFData Address where

--- a/Network/Haskoin/Crypto/BigWord.hs
+++ b/Network/Haskoin/Crypto/BigWord.hs
@@ -3,9 +3,8 @@
 module Network.Haskoin.Crypto.BigWord
 (
 -- Useful type aliases
-  Hash512
-, Hash256
-, Hash160
+  TxHash
+, BlockHash
 , Word512
 , Word256
 , Word160
@@ -18,12 +17,6 @@ module Network.Haskoin.Crypto.BigWord
 , BigWordMod(..)
 
 -- Functions
-, toFieldN
-, toFieldP
-, toMod512
-, toMod256
-, toMod160
-, toMod128
 , inverseP
 , inverseN
 , quadraticResidue
@@ -62,18 +55,19 @@ import Network.Haskoin.Crypto.Curve
 import Network.Haskoin.Crypto.NumberTheory 
 import Network.Haskoin.Util 
 
+-- | Type representing a transaction hash.
+type TxHash  = BigWord Mod256Tx
+-- | Type representing a block hash.
+type BlockHash = BigWord Mod256Block
 -- | Data type representing a 512 bit unsigned integer.
 -- It is implemented as an Integer modulo 2^512.
 type Word512 = BigWord Mod512
-type Hash512 = Word512
 -- | Data type representing a 256 bit unsigned integer.
 -- It is implemented as an Integer modulo 2^256.
 type Word256 = BigWord Mod256
-type Hash256 = Word256
 -- | Data type representing a 160 bit unsigned integer.
 -- It is implemented as an Integer modulo 2^160.
 type Word160 = BigWord Mod160
-type Hash160 = Word160
 -- | Data type representing a 128 bit unsigned integer.
 -- It is implemented as an Integer modulo 2^128.
 type Word128 = BigWord Mod128
@@ -84,6 +78,8 @@ type FieldN  = BigWord ModN
 
 data Mod512
 data Mod256 
+data Mod256Tx
+data Mod256Block
 data Mod160
 data Mod128
 data ModP
@@ -94,24 +90,6 @@ newtype BigWord n = BigWord { getBigWordInteger :: Integer }
 
 instance NFData (BigWord n) where
     rnf (BigWord n) = rnf n
-
-toFieldN :: BigWord n -> FieldN
-toFieldN (BigWord i) = fromInteger i
-
-toFieldP :: BigWord n -> FieldP
-toFieldP (BigWord i) = fromInteger i
-
-toMod512 :: BigWord n -> Word512
-toMod512 (BigWord i) = fromInteger i
-
-toMod256 :: BigWord n -> Word256
-toMod256 (BigWord i) = fromInteger i
-
-toMod160 :: BigWord n -> Word160
-toMod160 (BigWord i) = fromInteger i
-
-toMod128 :: BigWord n -> Word128
-toMod128 (BigWord i) = fromInteger i
 
 inverseP :: FieldP -> FieldP
 inverseP (BigWord i) = fromInteger $ mulInverse i curveP
@@ -128,6 +106,14 @@ instance BigWordMod Mod512 where
     rBitSize     _ = 512
 
 instance BigWordMod Mod256 where
+    rFromInteger i = BigWord $ i `mod` 2 ^ (256 :: Int)
+    rBitSize     _ = 256
+
+instance BigWordMod Mod256Tx where
+    rFromInteger i = BigWord $ i `mod` 2 ^ (256 :: Int)
+    rBitSize     _ = 256
+
+instance BigWordMod Mod256Block where
     rFromInteger i = BigWord $ i `mod` 2 ^ (256 :: Int)
     rBitSize     _ = 256
 
@@ -220,15 +206,43 @@ instance Fractional (BigWord ModN) where
 
 instance Binary (BigWord Mod512) where
     get = do
-        a <- fromIntegral <$> (get :: Get Hash256)
-        b <- fromIntegral <$> (get :: Get Hash256)
+        a <- fromIntegral <$> (get :: Get Word256)
+        b <- fromIntegral <$> (get :: Get Word256)
         return $ (a `shiftL` 256) + b
 
     put (BigWord i) = do
-        put $ (fromIntegral (i `shiftR` 256) :: Hash256)
-        put $ (fromIntegral i :: Hash256)
+        put $ (fromIntegral (i `shiftR` 256) :: Word256)
+        put $ (fromIntegral i :: Word256)
 
 instance Binary (BigWord Mod256) where
+    get = do
+        a <- fromIntegral <$> getWord64be
+        b <- fromIntegral <$> getWord64be
+        c <- fromIntegral <$> getWord64be
+        d <- fromIntegral <$> getWord64be
+        return $ (a `shiftL` 192) + (b `shiftL` 128) + (c `shiftL` 64) + d
+
+    put (BigWord i) = do
+        putWord64be $ fromIntegral (i `shiftR` 192)
+        putWord64be $ fromIntegral (i `shiftR` 128)
+        putWord64be $ fromIntegral (i `shiftR` 64)
+        putWord64be $ fromIntegral i
+
+instance Binary (BigWord Mod256Tx) where
+    get = do
+        a <- fromIntegral <$> getWord64be
+        b <- fromIntegral <$> getWord64be
+        c <- fromIntegral <$> getWord64be
+        d <- fromIntegral <$> getWord64be
+        return $ (a `shiftL` 192) + (b `shiftL` 128) + (c `shiftL` 64) + d
+
+    put (BigWord i) = do
+        putWord64be $ fromIntegral (i `shiftR` 192)
+        putWord64be $ fromIntegral (i `shiftR` 128)
+        putWord64be $ fromIntegral (i `shiftR` 64)
+        putWord64be $ fromIntegral i
+
+instance Binary (BigWord Mod256Block) where
     get = do
         a <- fromIntegral <$> getWord64be
         b <- fromIntegral <$> getWord64be
@@ -296,12 +310,12 @@ instance Binary (BigWord ModP) where
 
     -- Section 2.3.6 http://www.secg.org/download/aid-780/sec1-v2.pdf
     get = do
-        (BigWord i) <- get :: Get Hash256
+        (BigWord i) <- get :: Get Word256
         unless (i < curveP) (fail $ "Get: Integer not in FieldP: " ++ (show i))
         return $ fromInteger i
 
     -- Section 2.3.7 http://www.secg.org/download/aid-780/sec1-v2.pdf
-    put r = put $ toMod256 r
+    put r = put (fromIntegral r :: Word256)
          
 
 -- curveP = 3 (mod 4), thus Lagrange solutions apply

--- a/Network/Haskoin/Crypto/ECDSA.hs
+++ b/Network/Haskoin/Crypto/ECDSA.hs
@@ -118,7 +118,7 @@ instance NFData Signature where
 -- Section 4.1.3 http://www.secg.org/download/aid-780/sec1-v2.pdf
 -- | Safely sign a message inside the 'SecretT' monad. The 'SecretT' monad will
 -- generate a new nonce for each signature.
-signMsg :: Monad m => Hash256 -> PrvKey -> SecretT m Signature
+signMsg :: Monad m => Word256 -> PrvKey -> SecretT m Signature
 signMsg _ (PrvKey  0) = error "signMsg: Invalid private key 0"
 signMsg _ (PrvKeyU 0) = error "signMsg: Invalid private key 0"
 signMsg h d = do
@@ -131,7 +131,7 @@ signMsg h d = do
 
 -- | Sign a message using ECDSA deterministic signatures as defined by
 -- RFC 6979 <http://tools.ietf.org/html/rfc6979>
-detSignMsg :: Hash256 -> PrvKey -> Signature
+detSignMsg :: Word256 -> PrvKey -> Signature
 detSignMsg _ (PrvKey  0) = error "detSignMsg: Invalid private key 0"
 detSignMsg _ (PrvKeyU 0) = error "detSignMsg: Invalid private key 0"
 detSignMsg h d = go $ hmacDRBGNew (runPut' $ putPrvKey d) (encode' h) BS.empty
@@ -150,16 +150,16 @@ detSignMsg h d = go $ hmacDRBGNew (runPut' $ putPrvKey d) (encode' h) BS.empty
 -- Re-using the same nonce twice will expose the private keys
 -- Use signMsg within the SecretT monad or detSignMsg instead
 -- Section 4.1.3 http://www.secg.org/download/aid-780/sec1-v2.pdf
-unsafeSignMsg :: Hash256 -> FieldN -> (FieldN, Point) -> Maybe Signature
+unsafeSignMsg :: Word256 -> FieldN -> (FieldN, Point) -> Maybe Signature
 unsafeSignMsg _ 0 _ = Nothing
 unsafeSignMsg h d (k,p) = do
     -- 4.1.3.1 (4.1.3.2 not required)
     (x,_) <- getAffine p
     -- 4.1.3.3
-    let r = toFieldN x
+    let r = (fromIntegral x :: FieldN)
     guard (r /= 0)
     -- 4.1.3.4 / 4.1.3.5
-    let e = toFieldN h
+    let e = (fromIntegral h :: FieldN)
     -- 4.1.3.6
     let s' = (e + r*d)/k
         -- Canonicalize signatures: s <= order/2
@@ -171,17 +171,17 @@ unsafeSignMsg h d (k,p) = do
 
 -- Section 4.1.4 http://www.secg.org/download/aid-780/sec1-v2.pdf
 -- | Verify an ECDSA signature
-verifySig :: Hash256 -> Signature -> PubKey -> Bool
+verifySig :: Word256 -> Signature -> PubKey -> Bool
 -- 4.1.4.1 (r and s can not be zero)
 verifySig _ (Signature 0 _) _ = False
 verifySig _ (Signature _ 0) _ = False
 verifySig h (Signature r s) q = case getAffine p of
     Nothing      -> False
     -- 4.1.4.7 / 4.1.4.8
-    (Just (x,_)) -> (toFieldN x) == r
+    (Just (x,_)) -> (fromIntegral x :: FieldN) == r
   where 
     -- 4.1.4.2 / 4.1.4.3
-    e  = toFieldN h
+    e  = (fromIntegral h :: FieldN)
     -- 4.1.4.4
     s' = inverseN s
     u1 = e*s'

--- a/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -44,10 +44,11 @@ import Network.Haskoin.Util
 import Network.Haskoin.Crypto.Keys
 import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Crypto.Base58
+import Network.Haskoin.Crypto.BigWord
 
 {- See BIP32 for details: https://en.bitcoin.it/wiki/BIP_0032 -}
 
-type ChainCode = Hash256
+type ChainCode = Word256
 
 -- | Data type representing an extended BIP32 private key. An extended key
 -- is a node in a tree of key derivations. It has a depth in the tree, a 
@@ -213,11 +214,11 @@ xPubChild :: XPubKey -> Word32
 xPubChild k = clearBit (xPubIndex k) 31
 
 -- | Computes the key identifier of an extended private key.
-xPrvID :: XPrvKey -> Hash160
+xPrvID :: XPrvKey -> Word160
 xPrvID = xPubID . deriveXPubKey
 
 -- | Computes the key identifier of an extended public key.
-xPubID :: XPubKey -> Hash160
+xPubID :: XPubKey -> Word160
 xPubID = hash160 . hash256BS . encode' . xPubKey 
 
 -- | Computes the key fingerprint of an extended private key.

--- a/Network/Haskoin/Crypto/Hash.hs
+++ b/Network/Haskoin/Crypto/Hash.hs
@@ -1,9 +1,6 @@
 -- | Hashing functions and HMAC DRBG definition
 module Network.Haskoin.Crypto.Hash
-( Hash512
-, Hash256
-, Hash160
-, CheckSum32
+( CheckSum32
 , hash512
 , hash256
 , hash160
@@ -27,10 +24,13 @@ module Network.Haskoin.Crypto.Hash
 , join512
 , decodeCompact
 , encodeCompact
+, txHash
+, cbHash
+, headerHash
+, encodeTxHashLE
+, decodeTxHashLE
 ) where
 
-import Control.Applicative ((<$>))
-import Control.DeepSeq (NFData, rnf)
 import Control.Monad (replicateM)
 
 import Crypto.Hash 
@@ -44,7 +44,7 @@ import Crypto.MAC.HMAC (hmac)
 
 import Data.Word (Word16, Word32)
 import Data.Byteable (toBytes)
-import Data.Binary (Binary, get, put)
+import Data.Binary (Binary, get)
 import Data.Binary.Get (getWord32le)
 import Data.Bits 
     ( shiftL
@@ -65,20 +65,14 @@ import qualified Data.ByteString as BS
     , length
     , replicate
     , drop
+    , reverse
     )
 
 import Network.Haskoin.Util 
 import Network.Haskoin.Crypto.BigWord 
+import Network.Haskoin.Protocol.Types
 
--- | Data type representing a 32 bit checksum
-newtype CheckSum32 = CheckSum32 Word32 deriving (Show, Eq, Read)
-
-instance NFData CheckSum32 where
-    rnf (CheckSum32 w) = rnf w
-
-instance Binary CheckSum32 where
-    get = CheckSum32 <$> get
-    put (CheckSum32 w) = put w
+type CheckSum32 = Word32
 
 run512 :: BS.ByteString -> BS.ByteString
 run512 = (toBytes :: Digest SHA512 -> BS.ByteString) . hash
@@ -90,7 +84,7 @@ run160 :: BS.ByteString -> BS.ByteString
 run160 = (toBytes :: Digest RIPEMD160 -> BS.ByteString) . hash
 
 -- | Computes SHA-512.
-hash512 :: BS.ByteString -> Hash512
+hash512 :: BS.ByteString -> Word512
 hash512 bs = runGet' get (run512 bs)
 
 -- | Computes SHA-512 and returns the result as a bytestring.
@@ -98,7 +92,7 @@ hash512BS :: BS.ByteString -> BS.ByteString
 hash512BS bs = run512 bs
 
 -- | Computes SHA-256.
-hash256 :: BS.ByteString -> Hash256
+hash256 :: BS.ByteString -> Word256
 hash256 bs = runGet' get (run256 bs)
 
 -- | Computes SHA-256 and returns the result as a bytestring.
@@ -106,7 +100,7 @@ hash256BS :: BS.ByteString -> BS.ByteString
 hash256BS bs = run256 bs
 
 -- | Computes RIPEMD-160.
-hash160 :: BS.ByteString -> Hash160
+hash160 :: BS.ByteString -> Word160
 hash160 bs = runGet' get (run160 bs)
 
 -- | Computes RIPEMD-160 and returns the result as a bytestring.
@@ -114,7 +108,7 @@ hash160BS :: BS.ByteString -> BS.ByteString
 hash160BS bs = run160 bs
 
 -- | Computes two rounds of SHA-256.
-doubleHash256 :: BS.ByteString -> Hash256
+doubleHash256 :: BS.ByteString -> Word256
 doubleHash256 bs = runGet' get (run256 $ run256 bs)
 
 -- | Computes two rounds of SHA-256 and returns the result as a bytestring.
@@ -125,12 +119,12 @@ doubleHash256BS bs = run256 $ run256 bs
 
 -- | Computes a 32 bit checksum.
 chksum32 :: BS.ByteString -> CheckSum32
-chksum32 bs = CheckSum32 $ fromIntegral $ (doubleHash256 bs) `shiftR` 224
+chksum32 bs = fromIntegral $ (doubleHash256 bs) `shiftR` 224
 
 {- HMAC -}
 
 -- | Computes HMAC over SHA-512.
-hmac512 :: BS.ByteString -> BS.ByteString -> Hash512
+hmac512 :: BS.ByteString -> BS.ByteString -> Word512
 hmac512 key = decode' . (hmac512BS key)
 
 -- | Computes HMAC over SHA-512 and return the result as a bytestring.
@@ -138,20 +132,21 @@ hmac512BS :: BS.ByteString -> BS.ByteString -> BS.ByteString
 hmac512BS key msg = hmac hash512BS 128 key msg
 
 -- | Computes HMAC over SHA-256.
-hmac256 :: BS.ByteString -> BS.ByteString -> Hash256
+hmac256 :: BS.ByteString -> BS.ByteString -> Word256
 hmac256 key = decode' . (hmac256BS key)
 
 -- | Computes HMAC over SHA-256 and return the result as a bytestring.
 hmac256BS :: BS.ByteString -> BS.ByteString -> BS.ByteString
 hmac256BS key msg = hmac hash256BS 64 key msg
 
--- | Split a 'Hash512' into a pair of 'Hash256'.
-split512 :: Hash512 -> (Hash256, Hash256)
+-- | Split a 'Word512' into a pair of 'Word256'.
+split512 :: Word512 -> (Word256, Word256)
 split512 i = (fromIntegral $ i `shiftR` 256, fromIntegral i)
 
--- | Join a pair of 'Hash256' into a 'Hash512'.
-join512 :: (Hash256, Hash256) -> Hash512
-join512 (a,b) = ((toMod512 a) `shiftL` 256) + (toMod512 b)
+-- | Join a pair of 'Word256' into a 'Word512'.
+join512 :: (Word256, Word256) -> Word512
+join512 (a,b) = 
+    ((fromIntegral a :: Word512) `shiftL` 256) + (fromIntegral b :: Word512)
 
 -- | Decode the compact number used in the difficulty target of a block into an
 -- Integer. 
@@ -189,6 +184,29 @@ encodeCompact i
     (s2,c2) | c1 .&. 0x00800000 /= 0  = (s1 + 1, c1 `shiftR` 8)
             | otherwise               = (s1, c1)
     c3 = fromIntegral $ c2 .|. ((toInteger s2) `shiftL` 24)
+
+-- | Encodes a transaction hash as little endian in HEX format.
+-- This is mostly used for displaying transaction ids. Internally, these ids
+-- are handled as big endian but are transformed to little endian when
+-- displaying them.
+encodeTxHashLE :: TxHash -> String
+encodeTxHashLE = bsToHex . BS.reverse .  encode' 
+
+-- | Decodes a little endian transaction hash in HEX format. 
+decodeTxHashLE :: String -> Maybe TxHash
+decodeTxHashLE = (decodeToMaybe . BS.reverse =<<) . hexToBS
+
+-- | Computes the hash of a transaction.
+txHash :: Tx -> TxHash
+txHash = fromIntegral . doubleHash256 . encode' 
+
+-- | Computes the hash of a coinbase transaction.
+cbHash :: CoinbaseTx -> TxHash
+cbHash = fromIntegral . doubleHash256 . encode' 
+
+-- | Compute the hash of a block header
+headerHash :: BlockHeader -> BlockHash
+headerHash = fromIntegral . doubleHash256 . encode'
 
 {- 10.1.2 HMAC_DRBG with HMAC-SHA256
    http://csrc.nist.gov/publications/nistpubs/800-90A/SP800-90A.pdf 

--- a/Network/Haskoin/Crypto/Merkle.hs
+++ b/Network/Haskoin/Crypto/Merkle.hs
@@ -12,7 +12,12 @@ import Data.Maybe
 import qualified Data.ByteString as BS 
 
 import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Util
+
+type MerkleRoot        = Word256
+type FlagBits          = [Bool]
+type PartialMerkleTree = [Word256]
 
 -- | Computes the height of a merkle tree.
 calcTreeHeight :: Int -- ^ Number of transactions (leaf nodes).
@@ -27,21 +32,21 @@ calcTreeWidth :: Int -- ^ Number of transactions (leaf nodes).
 calcTreeWidth ntx h = (ntx + (1 `shiftL` h) - 1) `shiftR` h
 
 -- | Computes the root of a merkle tree from a list of leaf node hashes.
-buildMerkleRoot :: [Hash256] -- ^ List of transaction hashes (leaf nodes).
-                -> Hash256   -- ^ Root of the merkle tree.
+buildMerkleRoot :: [TxHash]   -- ^ List of transaction hashes (leaf nodes).
+                -> MerkleRoot -- ^ Root of the merkle tree.
 buildMerkleRoot txs = calcHash (calcTreeHeight $ length txs) 0 txs
 
-hash2 :: Hash256 -> Hash256 -> Hash256
+hash2 :: Word256 -> Word256 -> Word256
 hash2 a b = doubleHash256 $ encode' a `BS.append` encode' b
 
 -- | Computes the hash of a specific node in a merkle tree.
 calcHash :: Int       -- ^ Height of the node in the merkle tree.
          -> Int       -- ^ Position of the node (0 for the leftmost node).
-         -> [Hash256] -- ^ Transaction hashes of the merkle tree (leaf nodes).
-         -> Hash256   -- ^ Hash of the node at the specified position.
+         -> [TxHash]  -- ^ Transaction hashes of the merkle tree (leaf nodes).
+         -> Word256   -- ^ Hash of the node at the specified position.
 calcHash height pos txs
     | height < 0 || pos < 0 = error "calcHash: Invalid parameters"
-    | height == 0 = txs !! pos
+    | height == 0 = fromIntegral $ txs !! pos
     | otherwise = hash2 left right
   where
     left = calcHash (height-1) (pos*2) txs
@@ -51,16 +56,17 @@ calcHash height pos txs
 
 -- | Build a partial merkle tree.
 buildPartialMerkle 
-    :: [(Hash256,Bool)] 
+    :: [(TxHash,Bool)] 
     -- ^ List of transactions hashes forming the leaves of the merkle tree
     -- and a bool indicating if that transaction should be included in the 
     -- partial merkle tree.
-    -> ([Bool], [Hash256]) 
+    -> (FlagBits, PartialMerkleTree) 
     -- ^ Flag bits (used to parse the partial merkle tree) and the 
     -- partial merkle tree.
 buildPartialMerkle hs = traverseAndBuild (calcTreeHeight $ length hs) 0 hs
 
-traverseAndBuild :: Int -> Int -> [(Hash256,Bool)] -> ([Bool], [Hash256])
+traverseAndBuild :: Int -> Int -> [(TxHash,Bool)] 
+                 -> (FlagBits, PartialMerkleTree)
 traverseAndBuild height pos txs
     | height < 0 || pos < 0 = error "traverseAndBuild: Invalid parameters"
     | height == 0 || not match = ([match],[calcHash height pos t])
@@ -75,8 +81,8 @@ traverseAndBuild height pos txs
                 = traverseAndBuild (height-1) (pos*2+1) txs
             | otherwise = ([],[])
 
-traverseAndExtract :: Int -> Int -> Int -> [Bool] -> [Hash256] 
-                   -> Maybe (Hash256, [Hash256], Int, Int)
+traverseAndExtract :: Int -> Int -> Int -> FlagBits -> PartialMerkleTree
+                   -> Maybe (MerkleRoot, [TxHash], Int, Int)
 traverseAndExtract height pos ntx flags hashes
     | length flags == 0        = Nothing
     | height == 0 || not match = leafResult
@@ -89,7 +95,8 @@ traverseAndExtract height pos ntx flags hashes
   where
     leafResult
         | null hashes = Nothing
-        | otherwise = Just (h,if height == 0 && match then [h] else [],1,1)
+        | otherwise = Just 
+            (h,if height == 0 && match then [fromIntegral h] else [],1,1)
     (match:fs) = flags
     (h:_)     = hashes
     leftM  = traverseAndExtract (height-1) (pos*2) ntx fs hashes
@@ -101,10 +108,10 @@ traverseAndExtract height pos ntx flags hashes
 -- | Extracts the matching hashes from a partial merkle tree. This will return
 -- the list of transaction hashes that have been included (set to True) in
 -- a call to 'buildPartialMerkle'.
-extractMatches :: [Bool]    -- ^ Flag bits (produced by buildPartialMerkle).
-               -> [Hash256] -- ^ Partial merkle tree.
-               -> Int       -- ^ Number of transaction at height 0 (leaf nodes).
-               -> Either String (Hash256, [Hash256])
+extractMatches :: FlagBits -- ^ Flag bits (produced by buildPartialMerkle).
+               -> PartialMerkleTree -- ^ Partial merkle tree.
+               -> Int -- ^ Number of transaction at height 0 (leaf nodes).
+               -> Either String (MerkleRoot, [TxHash])
                -- ^ Merkle root and the list of matching transaction hashes.
 extractMatches flags hashes ntx
     | ntx == 0 = Left $
@@ -125,6 +132,5 @@ extractMatches flags hashes ntx
   where
     resM = traverseAndExtract (calcTreeHeight ntx) 0 ntx flags hashes
     (merkleRoot, matches, nBitsUsed, nHashUsed) = fromJust resM
-
 
 

--- a/Network/Haskoin/Protocol.hs
+++ b/Network/Haskoin/Protocol.hs
@@ -16,7 +16,6 @@ module Network.Haskoin.Protocol
 , GetHeaders(..)
 , Headers(..)
 , BlockHeaderCount
-, blockid
 
   -- * Requesting data
 , GetData(..)
@@ -27,14 +26,10 @@ module Network.Haskoin.Protocol
 
   -- *Transactions
 , Tx(..)
-, txid
-, cbid
 , CoinbaseTx(..)
 , TxIn(..)
 , TxOut(..)
 , OutPoint(..)
-, encodeTxid
-, decodeTxid
 
   -- * Merkle trees and bloom filters
 , MerkleBlock(..)

--- a/Network/Haskoin/Protocol/Types.hs
+++ b/Network/Haskoin/Protocol/Types.hs
@@ -4,7 +4,6 @@ module Network.Haskoin.Protocol.Types
 , Alert(..)
 , Block(..)
 , BlockHeader(..) 
-, blockid
 , BloomFlags(..)
 , BloomFilter(..)
 , FilterLoad(..)
@@ -31,10 +30,6 @@ module Network.Haskoin.Protocol.Types
 , TxOut(..)
 , OutPoint(..)
 , CoinbaseTx(..)
-, txid
-, cbid
-, encodeTxid
-, decodeTxid
 , VarInt(..)
 , VarString(..)
 , Version(..)
@@ -74,12 +69,11 @@ import qualified Data.Sequence as S (Seq, fromList, length)
 import qualified Data.ByteString as BS 
     ( ByteString
     , length
-    , reverse
     , takeWhile
     )
 
-import Network.Haskoin.Crypto.Hash 
 import Network.Haskoin.Util 
+import Network.Haskoin.Crypto.BigWord
 
 -- | Network address with a timestamp
 type NetworkAddressTime = (Word32, NetworkAddress)
@@ -169,10 +163,10 @@ data BlockHeader =
                   blockVersion   :: !Word32
                   -- | Hash of the previous block (parent) referenced by this
                   -- block.
-                , prevBlock      :: !Hash256
+                , prevBlock      :: !BlockHash
                   -- | Root of the merkle tree of all transactions pertaining
                   -- to this block.
-                , merkleRoot     :: !Hash256
+                , merkleRoot     :: !Word256
                   -- | Unix timestamp recording when this block was created
                 , blockTimestamp :: !Word32
                   -- | The difficulty target being used for this block
@@ -203,10 +197,6 @@ instance Binary BlockHeader where
         putWord32le bt
         putWord32le bb
         putWord32le n 
-
--- | Compute the hash of a block header
-blockid :: BlockHeader -> Hash256
-blockid = doubleHash256 . encode'
 
 -- | The bloom flags are used to tell the remote peer how to auto-update
 -- the provided bloom filter. 
@@ -304,7 +294,7 @@ instance Binary FilterAdd where
         put $ VarInt $ fromIntegral $ BS.length bs
         putByteString bs
 
-type BlockLocator = [Hash256]
+type BlockLocator = [BlockHash]
 
 -- | Data type representing a GetBlocks message request. It is used in the
 -- bitcoin protocol to retrieve blocks from a peer by providing it a
@@ -324,7 +314,7 @@ data GetBlocks =
               , getBlocksLocator  :: !BlockLocator
                 -- | Hash of the last desired block. If set to zero, the
                 -- maximum number of block hashes is returned (500).
-              , getBlocksHashStop :: !Hash256
+              , getBlocksHashStop :: !BlockHash
               } deriving (Eq, Show, Read)
 
 instance NFData GetBlocks where
@@ -386,7 +376,7 @@ data GetHeaders =
                , getHeadersBL       :: !BlockLocator
                  -- | Hash of the last desired block header. When set to zero,
                  -- the maximum number of block headers is returned (2000)
-               , getHeadersHashStop :: !Hash256
+               , getHeadersHashStop :: !BlockHash
                } deriving (Eq, Show, Read)
 
 instance NFData GetHeaders where
@@ -489,7 +479,7 @@ data InvVector =
                 -- | Type of the object referenced by this inventory vector
                 invType :: !InvType
                 -- | Hash of the object referenced by this inventory vector
-              , invHash :: !Hash256
+              , invHash :: !Word256
               } deriving (Eq, Show, Read)
 
 instance NFData InvVector where
@@ -508,11 +498,11 @@ data MerkleBlock =
                 , merkleTotalTxns :: !Word32
                   -- | Hashes in depth-first order. They are used to rebuild a
                   -- partial merkle tree.
-                , mHashes     :: ![Hash256]
+                , mHashes :: ![Word256]
                   -- | Flag bits, packed per 8 in a byte. Least significant bit
                   -- first. Flag bits are used to rebuild a partial merkle
                   -- tree.
-                , mFlags      :: ![Bool]
+                , mFlags :: ![Bool]
                 } deriving (Eq, Show, Read)
 
 instance NFData MerkleBlock where
@@ -859,7 +849,7 @@ instance Binary TxOut where
 data OutPoint = 
     OutPoint { 
                -- | The hash of the referenced transaction.
-               outPointHash  :: !Hash256
+               outPointHash  :: !TxHash
                -- | The position of the specific output in the transaction.
                -- The first output position is 0.
              , outPointIndex :: !Word32
@@ -873,25 +863,6 @@ instance Binary OutPoint where
         (h,i) <- liftM2 (,) get getWord32le
         return $ OutPoint h i
     put (OutPoint h i) = put h >> putWord32le i
-
--- | Computes the hash of a transaction.
-txid :: Tx -> Hash256
-txid = doubleHash256 . encode' 
-
--- | Computes the hash of a coinbase transaction.
-cbid :: CoinbaseTx -> Hash256
-cbid = doubleHash256 . encode' 
-
--- | Encodes a transaction hash as little endian in HEX format.
--- This is mostly used for displaying transaction ids. Internally, these ids
--- are handled as big endian but are transformed to little endian when
--- displaying them.
-encodeTxid :: Hash256 -> String
-encodeTxid = bsToHex . BS.reverse .  encode' 
-
--- | Decodes a little endian transaction hash in HEX format. 
-decodeTxid :: String -> Maybe Hash256
-decodeTxid = (decodeToMaybe . BS.reverse =<<) . hexToBS
 
 -- | Data type representing a variable length integer. The 'VarInt' type
 -- usually precedes an array or a string that can vary in length. 

--- a/Network/Haskoin/Script/SigHash.hs
+++ b/Network/Haskoin/Script/SigHash.hs
@@ -30,6 +30,7 @@ import qualified Data.ByteString as BS
     , empty
     )
 
+import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Crypto.ECDSA
 import Network.Haskoin.Script.Types
@@ -120,7 +121,7 @@ txSigHash :: Tx      -- ^ Transaction to sign.
           -> Script  -- ^ Output script that is being spent.
           -> Int     -- ^ Index of the input that is being signed.
           -> SigHash -- ^ What parts of the transaction should be signed.
-          -> Hash256 -- ^ Result hash to be signed.
+          -> Word256 -- ^ Result hash to be signed.
 txSigHash tx out i sh = do
     let newIn = buildInputs (txIn tx) out i sh
     -- When SigSingle and input index > outputs, then sign integer 1

--- a/Network/Haskoin/Stratum/Client.hs
+++ b/Network/Haskoin/Stratum/Client.hs
@@ -162,11 +162,11 @@ txParse :: Value -> Parser Tx
 txParse = withText "bitcoin transaction" $
     return . decode' . fromJust . hexToBS . Text.unpack
 
-txidParse :: Value -> Parser Hash256
+txidParse :: Value -> Parser TxHash
 txidParse = withText "transaction id" $
-    return . fromJust . decodeTxid . Text.unpack
+    return . fromJust . decodeTxHashLE . Text.unpack
 
-hashParse :: Value -> Parser Hash256
+hashParse :: Value -> Parser Word256
 hashParse = withText "hash" $
     return . decode' . fromJust . hexToBS . Text.unpack
 

--- a/tests/Network/Haskoin/Crypto/Arbitrary.hs
+++ b/tests/Network/Haskoin/Crypto/Arbitrary.hs
@@ -18,7 +18,6 @@ import Control.Applicative ((<$>), (<*>))
 import Data.Maybe
 
 import Network.Haskoin.Crypto.Point
-import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.ECDSA
 import Network.Haskoin.Crypto.Keys
@@ -36,9 +35,6 @@ instance BigWordMod Mod32 where
 
 instance BigWordMod n => Arbitrary (BigWord n) where
     arbitrary = arbitrarySizedBoundedIntegral
-
-instance Arbitrary CheckSum32 where
-    arbitrary = chksum32 <$> arbitrary
 
 instance Arbitrary Point where
     arbitrary = frequency

--- a/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
@@ -31,7 +31,7 @@ tests =
 
 {- ECDSA Signatures -}
 
-signAndVerify :: Hash256 -> FieldN -> FieldN -> Property
+signAndVerify :: Word256 -> FieldN -> FieldN -> Property
 signAndVerify msg k n = k > 0 && n > 0 ==> case sM of
     (Just s) -> verifySig msg s (PubKey kP)
     Nothing  -> True -- very bad luck
@@ -39,7 +39,7 @@ signAndVerify msg k n = k > 0 && n > 0 ==> case sM of
           nP = mulPoint n curveG
           sM = unsafeSignMsg msg k (n,nP)
 
-signAndVerifyD :: Hash256 -> TestPrvKeyC -> Bool
+signAndVerifyD :: Word256 -> TestPrvKeyC -> Bool
 signAndVerifyD msg (TestPrvKeyC k) = verifySig msg (detSignMsg msg k) p
     where p = derivePubKey k
            

--- a/tests/Network/Haskoin/Crypto/Hash/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Hash/Tests.hs
@@ -4,6 +4,7 @@ import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.Arbitrary()
 
 tests :: [Test]
@@ -14,7 +15,7 @@ tests =
         ]
     ]
 
-joinSplit512 :: Hash512 -> Bool
+joinSplit512 :: Word512 -> Bool
 joinSplit512 h = (join512 $ split512 h) == h
 
 -- After encoding and decoding, we may loose precision so the new result is >=

--- a/tests/Network/Haskoin/Crypto/Keys/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Keys/Tests.hs
@@ -113,21 +113,21 @@ deriveFromInt i = maybe True (isValidPubKey . derivePubKey) $ makePrvKey i
 
 {- Key properties -}
 
-testAddPubKey :: TestPrvKeyC -> Hash256 -> Bool
+testAddPubKey :: TestPrvKeyC -> Word256 -> Bool
 testAddPubKey (TestPrvKeyC key) i 
     | toInteger i >= curveN = isNothing res
     | model == InfPoint     = isNothing res
     | otherwise             = PubKey model == fromJust res
     where pub   = derivePubKey key
-          pt    = mulPoint (toFieldN i) curveG
+          pt    = mulPoint (fromIntegral i :: FieldN) curveG
           model = addPoint (pubKeyPoint pub) pt
           res   = addPubKeys pub i
 
-testAddPrvKey :: TestPrvKeyC -> Hash256 -> Bool
+testAddPrvKey :: TestPrvKeyC -> Word256 -> Bool
 testAddPrvKey (TestPrvKeyC key) i
     | toInteger i >= curveN = isNothing res
     | model == 0  = isNothing res
     | otherwise   = PrvKey model == fromJust res
-    where model = (prvKeyFieldN key) + (toFieldN i)
+    where model = (prvKeyFieldN key) + (fromIntegral i :: FieldN)
           res   = addPrvKeys key i
 

--- a/tests/Network/Haskoin/Crypto/Merkle/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Merkle/Tests.hs
@@ -25,7 +25,7 @@ testTreeWidth i = i > 0 ==> calcTreeWidth i (calcTreeHeight i) == 1
 testBaseWidth :: Int -> Property
 testBaseWidth i = i > 0 ==> calcTreeWidth i 0 == i
 
-buildExtractTree :: [(Hash256,Bool)] -> Property
+buildExtractTree :: [(TxHash,Bool)] -> Property
 buildExtractTree txs = not (null txs) ==>
     r == (buildMerkleRoot hashes) && m == (map fst $ filter snd txs)
   where

--- a/tests/Network/Haskoin/Crypto/Merkle/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Merkle/Units.hs
@@ -5,10 +5,8 @@ import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 
 import Data.Maybe (fromJust)
-import qualified Data.ByteString as BS (reverse)
 
 import Network.Haskoin.Crypto
-import Network.Haskoin.Util
 
 tests :: [Test]
 tests =
@@ -24,9 +22,10 @@ mapMerkleVectors (v,i) =
 
 runMerkleVector :: (String,[String]) -> Assertion
 runMerkleVector (r,hs) = do
-    assertBool "    >  Merkle Vector" $ buildMerkleRoot (map f hs) == (f r)
+    assertBool "    >  Merkle Vector" $ 
+        buildMerkleRoot (map f hs) == fromIntegral (f r)
   where
-    f = decode' . BS.reverse . fromJust . hexToBS
+    f = fromJust . decodeTxHashLE
 
 merkleVectors :: [(String,[String])]
 merkleVectors =

--- a/tests/Network/Haskoin/Crypto/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Units.hs
@@ -169,7 +169,7 @@ checkMatchingAddress = do
     assertBool "Key 1C" $ addr1C == (addrToBase58 $ pubKeyAddr pub1C)
     assertBool "Key 2C" $ addr2C == (addrToBase58 $ pubKeyAddr pub2C)
     
-checkSignatures :: Hash256 -> Assertion
+checkSignatures :: Word256 -> Assertion
 checkSignatures h = do
     (sign1, sign2, sign1C, sign2C) <- liftIO $ withSource devURandom $ do
         a <- signMsg h sec1
@@ -258,7 +258,7 @@ testDetSigning (prv,msg,str) = do
     where sig@(Signature r s) = detSignMsg msg' prv'
           msg' = hash256 $ stringToBS msg
           prv' = fromJust $ makePrvKey prv
-          res = runPut' $ put (fromIntegral r :: Hash256) >> 
-                          put (fromIntegral s :: Hash256)
+          res = runPut' $ put (fromIntegral r :: Word256) >> 
+                          put (fromIntegral s :: Word256)
 
 

--- a/tests/Network/Haskoin/Protocol/Arbitrary.hs
+++ b/tests/Network/Haskoin/Protocol/Arbitrary.hs
@@ -70,7 +70,7 @@ instance Arbitrary RejectCode where
 
 instance Arbitrary BlockHeader where
     arbitrary = BlockHeader <$> arbitrary
-                            <*> (hash256 <$> arbitrary)
+                            <*> (fromIntegral . hash256 <$> arbitrary)
                             <*> (hash256 <$> arbitrary)
                             <*> arbitrary
                             <*> arbitrary

--- a/tests/Network/Haskoin/Protocol/Tests.hs
+++ b/tests/Network/Haskoin/Protocol/Tests.hs
@@ -53,6 +53,6 @@ tests =
 metaGetPut :: (Binary a, Eq a) => a -> Bool
 metaGetPut x = (runGet get (runPut $ put x)) == x
 
-decEncTxid :: Hash256 -> Bool
-decEncTxid h = (fromJust $ decodeTxid $ encodeTxid h) == h
+decEncTxid :: TxHash -> Bool
+decEncTxid h = (fromJust $ decodeTxHashLE $ encodeTxHashLE h) == h
 

--- a/tests/Network/Haskoin/Protocol/Units.hs
+++ b/tests/Network/Haskoin/Protocol/Units.hs
@@ -6,7 +6,7 @@ import Test.Framework.Providers.HUnit (testCase)
 
 import Data.Maybe
 
-import Network.Haskoin.Protocol
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
 
 tests :: [Test]
@@ -22,7 +22,7 @@ mapTxIDVec (v,i) = testCase name $ runTxIDVec v
 
 runTxIDVec :: (String,String) -> Assertion
 runTxIDVec (tid,tx) = assertBool "TxID" $ 
-    (encodeTxid $ txid txBS) == tid
+    (encodeTxHashLE $ txHash txBS) == tid
   where 
     txBS = decode' $ fromJust $ hexToBS tx
 

--- a/tests/Network/Haskoin/Transaction/Units.hs
+++ b/tests/Network/Haskoin/Transaction/Units.hs
@@ -10,6 +10,7 @@ import Data.Binary.Get (getWord32le)
 import qualified Data.ByteString as BS (reverse)
 
 import Network.Haskoin.Transaction.Builder
+import Network.Haskoin.Crypto
 import Network.Haskoin.Protocol
 import Network.Haskoin.Util
 
@@ -30,7 +31,7 @@ runPKHashVec :: ([(String,Word32)],[(String,Word64)],String) -> Assertion
 runPKHashVec (xs,ys,res) = 
     assertBool "Build PKHash Tx" $ (bsToHex $ encode' tx) == res
     where tx = fromRight $ buildAddrTx (map f xs) ys
-          f (tid,ix) = OutPoint (fromJust $ decodeTxid tid) ix
+          f (tid,ix) = OutPoint (fromJust $ decodeTxHashLE tid) ix
 
 
 mapVerifyVec :: (([(String,String,String)],String),Int) 


### PR DESCRIPTION
I am introducing separates types in the type system for TxHash and BlockHash. I removed Hash512, Hash256 and Hash160. the Word512, Word256 and Word160 types remain. TxHash and BlockHash are separate types so that we can make separate instances for them and deal with them differently than Word256. You can explicitly convert between them using fromIntegral. I also shuffled some of the hashing functions around where I believe they make more sense.
