### PR TITLE
Fixing Signature Decoding Problem

### DIFF
--- a/Network/Haskoin/Crypto/BigWord.hs
+++ b/Network/Haskoin/Crypto/BigWord.hs
@@ -286,8 +286,6 @@ instance Binary (BigWord ModN) where
         unless (t == 0x02) (fail $
             "Bad DER identifier byte " ++ (show t) ++ ". Expecting 0x02" )
         l <- getWord8
-        unless (l <= 33) (fail $
-            "Bad DER length " ++ (show l) ++ ". Expecting length <= 33" )
         i <- bsToInteger <$> getByteString (fromIntegral l)
         unless (isIntegerValidKey i) $ fail $ 
             "Invalid fieldN element: " ++ (show i)

--- a/Network/Haskoin/Crypto/ECDSA.hs
+++ b/Network/Haskoin/Crypto/ECDSA.hs
@@ -202,8 +202,6 @@ instance Binary Signature where
             "Bad DER identifier byte " ++ (show t) ++ ". Expecting 0x30")
         l <- getWord8
         -- Length = (33 + 1 identifier byte + 1 length byte) * 2
-        unless (l <= 70) (fail $
-            "Bad DER length " ++ (show l) ++ ". Expecting length <= 70")
         isolate (fromIntegral l) $ do
             Signature <$> get <*> get
 

--- a/Network/Haskoin/Crypto/ECDSA.hs
+++ b/Network/Haskoin/Crypto/ECDSA.hs
@@ -203,7 +203,7 @@ instance Binary Signature where
         l <- getWord8
         -- Length = (33 + 1 identifier byte + 1 length byte) * 2
         unless (l <= 70) (fail $
-            "Bad DER length " ++ (show t) ++ ". Expecting length <= 70")
+            "Bad DER length " ++ (show l) ++ ". Expecting length <= 70")
         isolate (fromIntegral l) $ do
             Signature <$> get <*> get
 

--- a/tests/Network/Haskoin/Script/Units.hs
+++ b/tests/Network/Haskoin/Script/Units.hs
@@ -18,6 +18,8 @@ tests =
         (map notCanonicalVectorsMap $ zip notCanonicalVectors [0..])
     , testGroup "Multi Signatures" 
         (map mapMulSigVector $ zip mulSigVectors [0..])
+    , testGroup "Signature decoding"
+        (map sigDecodeMap $ zip scriptSigSignatures [0..])
     ]
 
 canonicalVectorsMap :: (String,Int) -> Test.Framework.Test
@@ -31,6 +33,12 @@ notCanonicalVectorsMap (_,i) =
     testCase ("Not canonical Sig " ++ (show i)) func
   where 
     func = testNotCanonicalSig $ notCanonicalVectors !! i
+    
+sigDecodeMap :: ( String, Int ) -> Test.Framework.Test    
+sigDecodeMap (_,i) =
+    testCase ( "Signature " ++ ( show i ) ) func
+  where
+    func = testSigDecode $ scriptSigSignatures !! i
 
 testCanonicalSig :: String -> Assertion
 testCanonicalSig str = 
@@ -56,6 +64,13 @@ runMulSigVector (a,ops) =
   where 
     s = decode' $ fromJust $ hexToBS ops
     b = addrToBase58 $ scriptAddr $ fromRight $ decodeOutput s
+    
+testSigDecode :: String -> Assertion
+testSigDecode str =
+  let bs = fromJust $ hexToBS str
+      eitherSig = decodeSig bs
+  in
+  assertBool ( unwords [ "Decode failed:", fromLeft eitherSig ] ) $ isRight eitherSig
 
 {- Canonical Signatures -}
 
@@ -97,3 +112,10 @@ mulSigVectors =
       ) 
     ]
 
+scriptSigSignatures :: [ String ]
+scriptSigSignatures =
+     -- Signature in input of txid 1983a69265920c24f89aac81942b1a59f7eb30821a8b3fb258f88882b6336053
+    [ "304402205ca6249f43538908151fe67b26d020306c0e59fa206cf9f3ccf641f33357119d02206c82f244d04ac0a48024fb9cc246b66e58598acf206139bdb7b75a2941a2b1e401"
+      -- Signature in input of txid fb0a1d8d34fa5537e461ac384bac761125e1bfa7fec286fa72511240fa66864d  Strange DER sizes. But in Blockchain
+    , "3048022200002b83d59c1d23c08efd82ee0662fec23309c3adbcbd1f0b8695378db4b14e736602220000334a96676e58b1bb01784cb7c556dd8ce1c220171904da22e18fe1e7d1510db501"
+    ]


### PR DESCRIPTION
decodeSig fails on a particular signature in the blockchain due to the assertions of the DER length.

The txid is fb0a1d8d34fa5537e461ac384bac761125e1bfa7fec286fa72511240fa66864d and the signature is in the input sigScript.

This pull request contains the removal of the assertions as well as a unit test illustrating and testing the problem and solution.
