### PR TITLE
Removing signature placeholders in partially signed transaction inputs

### DIFF
--- a/tests/Network/Haskoin/Script/Arbitrary.hs
+++ b/tests/Network/Haskoin/Script/Arbitrary.hs
@@ -90,9 +90,8 @@ instance Arbitrary ScriptInput where
 -- | Generate an arbitrary 'ScriptInput' of value SpendMulSig.
 genSpendMulSig :: Gen ScriptInput
 genSpendMulSig = do
-    m <- choose (1,16)
-    s <- choose (1,m)
-    SpendMulSig <$> (vectorOf s arbitrary) <*> (return m)
+    s <- choose (1,16)
+    SpendMulSig <$> (vectorOf s arbitrary)
 
 instance Arbitrary ScriptHashInput where
     arbitrary = ScriptHashInput <$> arbitrary <*> arbitrary

--- a/tests/Network/Haskoin/Transaction/Arbitrary.hs
+++ b/tests/Network/Haskoin/Transaction/Arbitrary.hs
@@ -60,7 +60,7 @@ genMulSigInput :: Gen ScriptHashInput
 genMulSigInput = do
     (MSParam m n) <- arbitrary
     rdm <- PayMulSig <$> (vectorOf n genPubKeyC) <*> (return m)
-    inp <- SpendMulSig <$> (vectorOf m arbitrary) <*> (return m)
+    inp <- SpendMulSig <$> (vectorOf m arbitrary)
     return $ ScriptHashInput inp rdm
 
 -- | Generate an arbitrary transaction input spending a public key hash or


### PR DESCRIPTION
In the spirit of interoperability with other libraries, this patch removes the signature placeholder we had in transaction inputs when an input was partially signed. Some changes had to be made to code that decides if an input is partial or complete. In some cases, the information is not available if we don't have access to the previous outputs of a transction (ex: regular SpendMulSig input). 
