### PR TITLE
Non-standard inputs must be considered complete

### DIFF
--- a/Network/Haskoin/Transaction/Builder.hs
+++ b/Network/Haskoin/Transaction/Builder.hs
@@ -311,8 +311,8 @@ getInputStatus (TxIn _ s _) sigiM
                 (Right (SpendMulSig xs), Just (Right (PayMulSig _ r))) ->
                     if length xs >= r then SigComplete else SigPartial
                 (Right (SpendMulSig _), Nothing) -> SigNeedPrevOut
-                (Right _, _) -> SigComplete
-                _ -> SigInvalid "Non-standard input"
+                -- If we can not decode an input, we consider it complete
+                _ -> SigComplete
 
 -- Order the SigInput with respect to the transaction inputs. This allow the
 -- users to provide the SigInput in any order. Users can also provide only a


### PR DESCRIPTION
As we have no introspection into non-standard inputs, they should not affect negatively the status of the whole transaction. We simply ignore them by setting the status to SigComplete.
