### PR TITLE
Simplified signatures

### DIFF
--- a/Network/Haskoin/Crypto/ECDSA.hs
+++ b/Network/Haskoin/Crypto/ECDSA.hs
@@ -49,7 +49,7 @@ type SecretState m = (WorkingState, (Int -> m BS.ByteString))
 -- | StateT monad stack tracking the internal state of HMAC DRBG 
 -- pseudo random number generator using SHA-256. The 'SecretT' monad is
 -- run with the 'withSource' function by providing it a source of entropy.
-type SecretT m a = S.StateT (SecretState m) m a
+type SecretT m = S.StateT (SecretState m) m
 
 -- | Run a 'SecretT' monad by providing it a source of entropy. You can
 -- use 'devURandom', 'devRandom' or provide your own entropy source function.

--- a/Network/Haskoin/Script.hs
+++ b/Network/Haskoin/Script.hs
@@ -42,6 +42,7 @@ module Network.Haskoin.Script
 , RedeemScript
 , getRedeem
 , appendRedeem
+, removeRedeem
 
   -- * Helpers
 , scriptRecipient

--- a/Network/Haskoin/Script.hs
+++ b/Network/Haskoin/Script.hs
@@ -37,13 +37,10 @@ module Network.Haskoin.Script
 , isSpendPKHash
 , isSpendMulSig
 
-  -- **ScriptHash Inputs
-, ScriptHashInput(..)
+  -- **Pay To Script Hash
 , RedeemScript
-, encodeScriptHash
-, encodeScriptHashBS
-, decodeScriptHash
-, decodeScriptHashBS
+, getRedeem
+, appendRedeem
 
   -- * Helpers
 , scriptRecipient

--- a/Network/Haskoin/Script.hs
+++ b/Network/Haskoin/Script.hs
@@ -12,6 +12,7 @@ module Network.Haskoin.Script
 , ScriptOp(..)
 , PushDataType(..)
 , opPushData
+, isPushOp
 
   -- *Script Parsing
   -- **Script Outputs

--- a/Network/Haskoin/Script/Parser.hs
+++ b/Network/Haskoin/Script/Parser.hs
@@ -25,6 +25,7 @@ module Network.Haskoin.Script.Parser
 , isSpendMulSig
 , getRedeem
 , appendRedeem
+, removeRedeem
 ) where
 
 import Control.DeepSeq (NFData, rnf)
@@ -321,7 +322,7 @@ getRedeem (Script ops) = do
   where
     (OP_PUSHDATA bs _) = last ops
 
--- | Append redeem script to end of sigscript.
+-- | Append redeem script to end of SigScript.
 appendRedeem :: ScriptInput
              -> RedeemScript
              -> Script
@@ -329,3 +330,16 @@ appendRedeem i r = Script $ si ++ [rdm]
   where
     si = scriptOps $ encodeInput i
     rdm = opPushData $ encodeOutputBS r
+
+-- | Remove redeem script from SigScript.
+removeRedeem :: Script
+             -> Either String Script
+removeRedeem (Script ops) = do
+    when (null ops) $ Left "removeRedeem: empty script"
+    when (not isdata) $ Left "removeRedeem: unexpected opcode"
+    return (Script ops')
+  where
+    ops' = init ops
+    isdata = case last ops of
+        OP_PUSHDATA _ _ -> True
+        _ -> False

--- a/Network/Haskoin/Script/Parser.hs
+++ b/Network/Haskoin/Script/Parser.hs
@@ -272,23 +272,23 @@ decodeInput pks sgs = go False pks sgs
             [OP_PUSHDATA sig _] -> do
                 dsig <- decodeSig sig
                 return (SpendPK dsig, o, p)
-            _ -> Left "Could not decode script as SpendPK"
+            _ -> Left "decodeInput: could not decode script as SpendPK"
         PayPKHash _ -> case scriptOps i of
             [OP_PUSHDATA sig _, OP_PUSHDATA pub _] -> do
                 dsig <- decodeSig sig
                 dpub <- decodeToEither pub
                 return (SpendPKHash dsig dpub, o, p)
-            _ -> Left "Could not decode script as SpendPKHash"
+            _ -> Left "decodeInput: could not decode script as SpendPKHash"
         PayMulSig _ r -> case scriptOps i of
             OP_PUSHDATA _ _ : xs -> do
                 ms <- matchSpendMulSig (Script xs) r
                 return (ms, o, p)
-            _ -> Left "Could not decode script as SpendMulSig"
+            _ -> Left "decodeInput: could not decode script as SpendMulSig"
         PayScriptHash a -> do
-            when p $ Left "Nested P2SH scrpt"
+            when p $ Left "decodeInput: nested P2SH scrpt"
             out <- getRedeem $ Script (scriptOps i)
             unless (scriptAddr out == a) $
-                Left "Address doesn't match redeem script"
+                Left "decodeInput: address doesn't match redeem script"
             go True out $ Script (init $ scriptOps i)
 
 -- | Similar to 'decodeInput' but decodes from a ByteString.

--- a/Network/Haskoin/Script/Parser.hs
+++ b/Network/Haskoin/Script/Parser.hs
@@ -285,6 +285,7 @@ decodeInput pks sgs = go False pks sgs
                 return (ms, o, p)
             _ -> Left "Could not decode script as SpendMulSig"
         PayScriptHash a -> do
+            when p $ Left "Nested P2SH scrpt"
             out <- getRedeem $ Script (scriptOps i)
             unless (scriptAddr out == a) $
                 Left "Address doesn't match redeem script"

--- a/Network/Haskoin/Script/Types.hs
+++ b/Network/Haskoin/Script/Types.hs
@@ -3,6 +3,7 @@ module Network.Haskoin.Script.Types
 , Script(..)
 , PushDataType(..)
 , opPushData
+, isPushOp
 ) where
 
 import Control.DeepSeq (NFData, rnf)
@@ -210,6 +211,29 @@ instance Binary ScriptOp where
         OP_CHECKSIG          -> putWord8 0xac
         OP_CHECKMULTISIG     -> putWord8 0xae
         (OP_INVALIDOPCODE _) -> putWord8 0xff
+
+-- | Check whether opcode is only data.
+isPushOp :: ScriptOp -> Bool
+isPushOp (OP_PUSHDATA _ _) = True
+isPushOp OP_0              = True
+isPushOp OP_1NEGATE        = True
+isPushOp OP_1              = True
+isPushOp OP_2              = True
+isPushOp OP_3              = True
+isPushOp OP_4              = True
+isPushOp OP_5              = True
+isPushOp OP_6              = True
+isPushOp OP_7              = True
+isPushOp OP_8              = True
+isPushOp OP_9              = True
+isPushOp OP_10             = True
+isPushOp OP_11             = True
+isPushOp OP_12             = True
+isPushOp OP_13             = True
+isPushOp OP_14             = True
+isPushOp OP_15             = True
+isPushOp OP_16             = True
+isPushOp _                 = False
 
 -- | Optimally encode data using one of the 4 types of data pushing opcodes
 opPushData :: BS.ByteString -> ScriptOp

--- a/Network/Haskoin/Transaction.hs
+++ b/Network/Haskoin/Transaction.hs
@@ -10,8 +10,6 @@ module Network.Haskoin.Transaction
 
   -- *Transaction signing
 , SigInput(..)
-, SigStatus(..)
-, isSigInvalid
 , signTx
 , signInput
 , detSignTx

--- a/Network/Haskoin/Transaction/Builder.hs
+++ b/Network/Haskoin/Transaction/Builder.hs
@@ -218,7 +218,7 @@ msAddSig :: Tx             -- ^ Signed transaction
          -> Either String ScriptInput
          -- ^ Input with added signature
 msAddSig tx ini pks@(PayMulSig pubs r) (SpendMulSig sigs _) sig = do
-    when (not $ sig `elem` sigs) $ Left "msAddSig: invalid signature provided"
+    when (not $ sig `elem` sigs') $ Left "msAddSig: invalid signature provided"
     return $ SpendMulSig (take r sigs') r
   where
     msg h = txSigHash tx (encodeOutput pks) ini h

--- a/tests/Network/Haskoin/Script/Arbitrary.hs
+++ b/tests/Network/Haskoin/Script/Arbitrary.hs
@@ -93,20 +93,6 @@ genSpendMulSig r = do
     s <- choose (1,r)
     flip SpendMulSig r <$> (vectorOf s arbitrary)
 
-instance Arbitrary ScriptHashInput where
-    arbitrary = do
-        out <- oneof 
-            [ PayPK <$> arbitrary
-            , (PayPKHash . pubKeyAddr) <$> arbitrary 
-            , genPayMulSig
-            ]
-        inp <- case out of
-            (PayPK _)         -> SpendPK <$> arbitrary
-            (PayPKHash _)     -> SpendPKHash <$> arbitrary <*> arbitrary
-            (PayMulSig _ r)   -> genSpendMulSig r
-            _                 -> error "Won't happen"
-        return $ ScriptHashInput inp out
-
 -- | Data type for generating an arbitrary 'ScriptOp' with a value in
 -- [OP_1 .. OP_16]
 data ScriptOpInt = ScriptOpInt ScriptOp

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -33,6 +33,8 @@ tests =
     , testGroup "Script Parser"
         [ testProperty "decode . encode OP_1 .. OP_16" testScriptOpInt
         , testProperty "decode . encode ScriptOutput" testScriptOutput
+        , testProperty "decode . encode ScriptInput" testScriptInput
+        , testProperty "decode . encode ScriptHashInput" testScriptHashInput
         , testProperty "sorting MultiSig scripts" testSortMulSig
         ]
     , testGroup "Script SigHash"
@@ -56,6 +58,13 @@ testScriptOpInt (ScriptOpInt i) = (intToScriptOp <$> scriptOpToInt i) == Right i
 
 testScriptOutput :: ScriptOutput -> Bool
 testScriptOutput so = (decodeOutput $ encodeOutput so) == Right so
+
+testScriptInput :: ScriptHashInput -> Bool
+testScriptInput (ScriptHashInput si so) = 
+    (decodeInput so $ encodeInput si) == Right si
+
+testScriptHashInput :: ScriptHashInput -> Bool
+testScriptHashInput sh = (decodeScriptHash $ encodeScriptHash sh) == Right sh
 
 testSortMulSig :: ScriptOutput -> Bool
 testSortMulSig out = case out of

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -33,8 +33,6 @@ tests =
     , testGroup "Script Parser"
         [ testProperty "decode . encode OP_1 .. OP_16" testScriptOpInt
         , testProperty "decode . encode ScriptOutput" testScriptOutput
-        , testProperty "decode . encode ScriptInput" testScriptInput
-        , testProperty "decode . encode ScriptHashInput" testScriptHashInput
         , testProperty "sorting MultiSig scripts" testSortMulSig
         ]
     , testGroup "Script SigHash"
@@ -58,13 +56,6 @@ testScriptOpInt (ScriptOpInt i) = (intToScriptOp <$> scriptOpToInt i) == Right i
 
 testScriptOutput :: ScriptOutput -> Bool
 testScriptOutput so = (decodeOutput $ encodeOutput so) == Right so
-
-testScriptInput :: ScriptHashInput -> Bool
-testScriptInput (ScriptHashInput si so) = 
-    (decodeInput so $ encodeInput si) == Right si
-
-testScriptHashInput :: ScriptHashInput -> Bool
-testScriptHashInput sh = (decodeScriptHash $ encodeScriptHash sh) == Right sh
 
 testSortMulSig :: ScriptOutput -> Bool
 testSortMulSig out = case out of

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString as BS
     )
 
 import Network.Haskoin.Protocol.Arbitrary ()
-import Network.Haskoin.Script.Arbitrary (ScriptOpInt(..))
+import Network.Haskoin.Script.Arbitrary 
 
 import Network.Haskoin.Script
 import Network.Haskoin.Crypto
@@ -34,7 +34,6 @@ tests =
         [ testProperty "decode . encode OP_1 .. OP_16" testScriptOpInt
         , testProperty "decode . encode ScriptOutput" testScriptOutput
         , testProperty "decode . encode ScriptInput" testScriptInput
-        , testProperty "decode . encode ScriptHashInput" testScriptHashInput
         , testProperty "sorting MultiSig scripts" testSortMulSig
         ]
     , testGroup "Script SigHash"
@@ -59,12 +58,12 @@ testScriptOpInt (ScriptOpInt i) = (intToScriptOp <$> scriptOpToInt i) == Right i
 testScriptOutput :: ScriptOutput -> Bool
 testScriptOutput so = (decodeOutput $ encodeOutput so) == Right so
 
-testScriptInput :: ScriptHashInput -> Bool
-testScriptInput (ScriptHashInput si so) = 
-    (decodeInput so $ encodeInput si) == Right si
-
-testScriptHashInput :: ScriptHashInput -> Bool
-testScriptHashInput sh = (decodeScriptHash $ encodeScriptHash sh) == Right sh
+testScriptInput :: ScriptPair -> Bool
+testScriptInput (ScriptPair si so) = either (const False) id $ do
+    (sgs, pks, p2s) <- decodeInput so si
+    case so of
+        PayScriptHash a -> return $ p2s && scriptAddr pks == a
+        _ -> return $ not p2s && (encodeInput sgs) == si && pks == so
 
 testSortMulSig :: ScriptOutput -> Bool
 testSortMulSig out = case out of

--- a/tests/Network/Haskoin/Transaction/Arbitrary.hs
+++ b/tests/Network/Haskoin/Transaction/Arbitrary.hs
@@ -139,7 +139,7 @@ genPayTo = do
 -- Generates data for signing a PKHash transaction
 instance Arbitrary PKHashSigTemplate where
     arbitrary = do
-        inC   <- choose (0,5)
+        inC   <- choose (1,5)
         outC  <- choose (0,10)
         dat   <- nubBy (\a b -> fst3 a == fst3 b) <$> vectorOf inC genPKHashData
         perm  <- choose (0,max 0 $ length dat - 1)
@@ -151,7 +151,7 @@ instance Arbitrary PKHashSigTemplate where
 -- Generates data for signing a P2SH transactions
 instance Arbitrary MulSigTemplate where
     arbitrary = do
-        inC   <- choose (0,5)
+        inC   <- choose (1,5)
         outC  <- choose (0,10)
         dat   <- nubBy (\a b -> f1 a == f1 b) <$> vectorOf inC genMSData
         perm  <- choose (0,max 0 $ length dat - 1)

--- a/tests/Network/Haskoin/Transaction/Arbitrary.hs
+++ b/tests/Network/Haskoin/Transaction/Arbitrary.hs
@@ -56,12 +56,12 @@ genPubKeyC = derivePubKey <$> genPrvKeyC
 
 -- | Generate an arbitrary script hash input spending a multisignature
 -- pay to script hash.
-genMulSigInput :: Gen ScriptHashInput
+genMulSigInput :: Gen Script
 genMulSigInput = do
     (MSParam m n) <- arbitrary
     rdm <- PayMulSig <$> (vectorOf n genPubKeyC) <*> (return m)
     inp <- (flip SpendMulSig m) <$> (vectorOf m arbitrary)
-    return $ ScriptHashInput inp rdm
+    return $ appendRedeem inp rdm
 
 -- | Generate an arbitrary transaction input spending a public key hash or
 -- script hash output.
@@ -69,7 +69,7 @@ genRegularInput :: Gen TxIn
 genRegularInput = do
     op <- arbitrary
     sq <- arbitrary
-    sc <- oneof [ encodeScriptHashBS <$> genMulSigInput
+    sc <- oneof [ encode' <$> genMulSigInput
                 , encodeInputBS <$> (SpendPKHash <$> arbitrary <*> genPubKeyC)
                 ]
     return $ TxIn op sc sq

--- a/tests/Network/Haskoin/Transaction/Arbitrary.hs
+++ b/tests/Network/Haskoin/Transaction/Arbitrary.hs
@@ -139,7 +139,7 @@ genPayTo = do
 -- Generates data for signing a PKHash transaction
 instance Arbitrary PKHashSigTemplate where
     arbitrary = do
-        inC   <- choose (1,5)
+        inC   <- choose (0,5)
         outC  <- choose (0,10)
         dat   <- nubBy (\a b -> fst3 a == fst3 b) <$> vectorOf inC genPKHashData
         perm  <- choose (0,max 0 $ length dat - 1)
@@ -151,7 +151,7 @@ instance Arbitrary PKHashSigTemplate where
 -- Generates data for signing a P2SH transactions
 instance Arbitrary MulSigTemplate where
     arbitrary = do
-        inC   <- choose (1,5)
+        inC   <- choose (0,5)
         outC  <- choose (0,10)
         dat   <- nubBy (\a b -> f1 a == f1 b) <$> vectorOf inC genMSData
         perm  <- choose (0,max 0 $ length dat - 1)

--- a/tests/Network/Haskoin/Transaction/Tests.hs
+++ b/tests/Network/Haskoin/Transaction/Tests.hs
@@ -83,32 +83,32 @@ testChooseMSCoins target kbfee (MSParam m n) xs =
 {- Signing Transactions -}
 
 testSignTx :: PKHashSigTemplate -> Bool
-testSignTx (PKHashSigTemplate tx sigi prv)
-    | null $ txIn tx = isSigInvalid stat && isSigInvalid statP
-    | otherwise = (not $ verifyTx tx verData)
-                   && stat == SigComplete
-                   && verifyTx txSig verData
-                   && statP == SigPartial
-                   && (not $ verifyTx txSigP verData)
-                   && statC == SigComplete
-                   && verifyTx txSigC verData
-    where (txSig, stat)   = detSignTx tx sigi prv
-          (txSigP, statP) = detSignTx tx sigi (tail prv)
-          (txSigC, statC) = detSignTx txSigP sigi [head prv]
-          verData = map (\(SigInput s o _ _) -> (s,o)) sigi
+testSignTx (PKHashSigTemplate tx sigi prv) =
+    (not $ verifyTx tx verData)
+        && stat
+        && verifyTx txSig verData
+        && not statP
+        && (not $ verifyTx txSigP verData)
+        && statC
+        && verifyTx txSigC verData
+  where
+    (txSig, stat)   = detSignTx tx sigi prv
+    (txSigP, statP) = detSignTx tx sigi (tail prv)
+    (txSigC, statC) = detSignTx txSigP sigi [head prv]
+    verData = map (\(SigInput s o _ _) -> (s,o)) sigi
          
 testSignMS :: MulSigTemplate -> Bool
-testSignMS (MulSigTemplate tx sigis prv)
-    | null $ txIn tx = isSigInvalid stat && isSigInvalid statP
-    | otherwise = (not $ verifyTx tx verData)
-                && stat == SigComplete
-                && verifyTx txSig verData
-                && statP == SigPartial
-                && (not $ verifyTx txSigP verData)
-                && statC == SigComplete
-                && verifyTx txSigC verData
-    where (txSig, stat)    = detSignTx tx (map snd sigis) prv
-          (txSigP, statP)  = detSignTx tx (map snd sigis) (tail prv)
-          (txSigC, statC)  = detSignTx txSigP (map snd sigis) [head prv]
-          verData = map (\(s, (SigInput _ o _ _)) -> (s,o)) sigis
+testSignMS (MulSigTemplate tx sigis prv) =
+    (not $ verifyTx tx verData)
+        && stat
+        && verifyTx txSig verData
+        && not statP
+        && (not $ verifyTx txSigP verData)
+        && statC
+        && verifyTx txSigC verData
+  where
+    (txSig, stat)    = detSignTx tx (map snd sigis) prv
+    (txSigP, statP)  = detSignTx tx (map snd sigis) (tail prv)
+    (txSigC, statC)  = detSignTx txSigP (map snd sigis) [head prv]
+    verData = map (\(s, (SigInput _ o _ _)) -> (s,o)) sigis
 


### PR DESCRIPTION
Superseded by pull request #50.

I believe transaction signature was too convoluted in the original code. Instead of trying to work iteratively to refactor that code, I decided to roll my own, replacing the way transaction signatures are made and validated. The main goal of this code is clarity: to be easier to read, and precision. I spent part of the week mapping out the behaviour of bitcoind's signing code in order to come up with this scheme.

Some highlights are:
- No separate code or types for P2SH transactions
- Removal of signature status type, it is enough to use a boolean value to convey transaction signature status
- Code common to monadic (SecretT) and deterministic signing code factored out
- Signing functions split according to function and layer of abstraction, with intuitive naming and documentation
- Interface of higher-level function remains mostly unchanged
- Signature validation to determine whether transaction is completely signed is performed at the highest layer
- Reduction and confinement of code that makes contextual deductions, in favor of explicit parameters

My branch in terms of lines of code is a tad longer than plaprade's similar modifications by a small number of lines, but this code has more documentation, and is written in a sparse style for readability.
