### PR TITLE
Simplify Mnemonic and remove dependency on ICU

### DIFF
--- a/Network/Haskoin/Crypto.hs
+++ b/Network/Haskoin/Crypto.hs
@@ -100,7 +100,6 @@ module Network.Haskoin.Crypto
 , decodeBase58Check
 
   -- *Mnemonic keys (BIP-0039)
-, WordList
 , Entropy
 , Mnemonic
 , Passphrase
@@ -108,8 +107,6 @@ module Network.Haskoin.Crypto
 , toMnemonic
 , fromMnemonic
 , mnemonicToSeed
-, anyToSeed
-, english
 
   -- *Extended Keys
 , ChainCode

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -77,7 +77,6 @@ library
                        stm                  >= 2.4  && < 2.5,
                        stm-conduit          >= 2.4  && < 2.5,
                        text                 >= 1.1 && < 1.2,
-                       text-icu             >= 0.6  && < 0.7,
                        vector               >= 0.10 && < 0.11
     ghc-options:       -Wall -fno-warn-orphans
 
@@ -133,7 +132,7 @@ test-suite test-haskoin
                        stm                        >= 2.4  && < 2.5,
                        stm-conduit                >= 2.4  && < 2.5,
                        text                       >= 1.1 && < 1.2,
-                       text-icu                   >= 0.6  && < 0.7,
+                       vector                     >= 0.10 && < 0.11,
                        HUnit                      >= 1.2  && < 1.3,
                        QuickCheck                 >= 2.6  && < 2.7,
                        test-framework             >= 0.8  && < 0.9, 

--- a/tests/Network/Haskoin/Crypto/Mnemonic/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Mnemonic/Tests.hs
@@ -3,7 +3,6 @@ module Network.Haskoin.Crypto.Mnemonic.Tests (tests) where
 
 import Data.Bits ((.&.), shiftR)
 import Data.Binary (Binary)
-import qualified Data.Text as T
 import Data.Word (Word32)
 import qualified Data.ByteString as BS
 import Network.Haskoin.Crypto.Arbitrary()
@@ -55,25 +54,25 @@ toMnemonic128 :: Word128 -> Bool
 toMnemonic128 x = l == 12
   where
     bs = encode' x
-    l = length . T.words . fromRight $ toMnemonic english bs
+    l = length . words . fromRight $ toMnemonic bs
 
 toMnemonic160 :: Word160 -> Bool
 toMnemonic160 x = l == 15
   where
     bs = encode' x
-    l = length . T.words . fromRight $ toMnemonic english bs
+    l = length . words . fromRight $ toMnemonic bs
 
 toMnemonic256 :: Word256 -> Bool
 toMnemonic256 x = l == 24
   where
     bs = encode' x
-    l = length . T.words . fromRight $ toMnemonic english bs
+    l = length . words . fromRight $ toMnemonic bs
 
 toMnemonic512 :: Word512 -> Bool
 toMnemonic512 x = l == 48
   where
     bs = encode' x
-    l = length . T.words . fromRight $ toMnemonic english bs
+    l = length . words . fromRight $ toMnemonic bs
 
 toMnemonicVar :: [Word32] -> Property
 toMnemonicVar ls = not (length ls > 8) ==> l == wc
@@ -82,7 +81,7 @@ toMnemonicVar ls = not (length ls > 8) ==> l == wc
     bl = BS.length bs
     cb = bl `div` 4
     wc = (cb + bl * 8) `div` 11
-    l = length . T.words . fromRight $ toMnemonic english bs
+    l = length . words . fromRight $ toMnemonic bs
 
 {- Encode/Decode -}
 
@@ -90,31 +89,31 @@ fromToMnemonic128 :: Word128 -> Bool
 fromToMnemonic128 x = bs == bs'
   where
     bs = encode' x
-    bs' = fromRight (fromMnemonic english =<< toMnemonic english bs)
+    bs' = fromRight (fromMnemonic =<< toMnemonic bs)
 
 fromToMnemonic160 :: Word160 -> Bool
 fromToMnemonic160 x = bs == bs'
   where
     bs = encode' x
-    bs' = fromRight (fromMnemonic english =<< toMnemonic english bs)
+    bs' = fromRight (fromMnemonic =<< toMnemonic bs)
 
 fromToMnemonic256 :: Word256 -> Bool
 fromToMnemonic256 x = bs == bs'
   where
     bs = encode' x
-    bs' = fromRight (fromMnemonic english =<< toMnemonic english bs)
+    bs' = fromRight (fromMnemonic =<< toMnemonic bs)
 
 fromToMnemonic512 :: Word512 -> Bool
 fromToMnemonic512 x = bs == bs'
   where
     bs = encode' x
-    bs' = fromRight (fromMnemonic english =<< toMnemonic english bs)
+    bs' = fromRight (fromMnemonic =<< toMnemonic bs)
 
 fromToMnemonicVar :: [Word32] -> Property
 fromToMnemonicVar ls = not (length ls > 8) ==> bs == bs'
   where
     bs = binWordsToBS ls
-    bs' = fromRight (fromMnemonic english =<< toMnemonic english bs)
+    bs' = fromRight (fromMnemonic =<< toMnemonic bs)
 
 {- Mnemonic to seed -}
 
@@ -122,35 +121,35 @@ mnemonicToSeed128 :: Word128 -> Bool
 mnemonicToSeed128 x = l == 64
   where
     bs = encode' x
-    seed = fromRight (mnemonicToSeed english "" =<< toMnemonic english bs)
+    seed = fromRight (mnemonicToSeed "" =<< toMnemonic bs)
     l = BS.length seed
 
 mnemonicToSeed160 :: Word160 -> Bool
 mnemonicToSeed160 x = l == 64
   where
     bs = encode' x
-    seed = fromRight (mnemonicToSeed english "" =<< toMnemonic english bs)
+    seed = fromRight (mnemonicToSeed "" =<< toMnemonic bs)
     l = BS.length seed
 
 mnemonicToSeed256 :: Word256 -> Bool
 mnemonicToSeed256 x = l == 64
   where
     bs = encode' x
-    seed = fromRight (mnemonicToSeed english "" =<< toMnemonic english bs)
+    seed = fromRight (mnemonicToSeed "" =<< toMnemonic bs)
     l = BS.length seed
 
 mnemonicToSeed512 :: Word512 -> Bool
 mnemonicToSeed512 x = l == 64
   where
     bs = encode' x
-    seed = fromRight (mnemonicToSeed english "" =<< toMnemonic english bs)
+    seed = fromRight (mnemonicToSeed "" =<< toMnemonic bs)
     l = BS.length seed
 
 mnemonicToSeedVar :: [Word32] -> Property
 mnemonicToSeedVar ls = not (length ls > 16) ==> l == 64
   where
     bs = binWordsToBS ls
-    seed = fromRight (mnemonicToSeed english "" =<< toMnemonic english bs)
+    seed = fromRight (mnemonicToSeed "" =<< toMnemonic bs)
     l = BS.length seed
 
 {- Get bits from ByteString -}

--- a/tests/Network/Haskoin/Crypto/Mnemonic/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Mnemonic/Units.hs
@@ -6,7 +6,6 @@ import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 
 import Data.Maybe (fromJust)
-import qualified Data.Text as T
 import Network.Haskoin.Crypto.Mnemonic
 import Network.Haskoin.Util (hexToBS, bsToHex, fromRight)
 
@@ -22,22 +21,22 @@ toMnemonicTest = map f $ zip ents mss
   where
     f (e, m) = g e . assertEqual "" m . h $ e
     g = testCase
-    h = fromRight . toMnemonic english . fromJust . hexToBS
+    h = fromRight . toMnemonic . fromJust . hexToBS
 
 fromMnemonicTest :: [Test]
 fromMnemonicTest = map f $ zip ents mss
   where
     f (e, m) = g e . assertEqual "" e . h $ m
     g = testCase
-    h = bsToHex . fromRight . fromMnemonic english
+    h = bsToHex . fromRight . fromMnemonic
 
 mnemonicToSeedTest :: [Test]
 mnemonicToSeedTest = map f $ zip mss seeds
   where
     f (m, s) = g s . assertEqual "" s . h $ m
     g = testCase . (++ "...") . take 50
-    h = bsToHex . fromRight . mnemonicToSeed english "TREZOR"
-    
+    h = bsToHex . fromRight . mnemonicToSeed "TREZOR"
+
 
 ents :: [String]
 ents =
@@ -67,7 +66,7 @@ ents =
     , "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419"
     ]
 
-mss :: [T.Text]
+mss :: [Mnemonic]
 mss =
     [ "abandon abandon abandon abandon abandon abandon abandon abandon abandon\
       \ abandon abandon about"


### PR DESCRIPTION
Mnemonic simplification:
- Does not support non-ASCII mnemonics
- Does not depend on ICU library
- Only supports English word list
- Uses String instead of Text
- Uses Vector instead of a list for dictionary
- Has embedded Map to quickly find words in dictionary
