### PR TITLE
Script: Honor size limits, handle reserved words correctly, support PayToScriptHash

### DIFF
--- a/Network/Haskoin/Script/Evaluator.hs
+++ b/Network/Haskoin/Script/Evaluator.hs
@@ -266,7 +266,7 @@ pickStack remove n = do
 
     when (n < 0) $
         programError "pickStack: n < 0"
-    when (n > (length stack)) $
+    when (n > (length stack) - 1) $
         programError "pickStack: n > size"
 
     let v = stack !! n

--- a/Network/Haskoin/Script/Evaluator.hs
+++ b/Network/Haskoin/Script/Evaluator.hs
@@ -197,7 +197,9 @@ isDisabled op = op `elem` [ OP_CAT
                           , OP_MUL
                           , OP_MOD
                           , OP_LSHIFT
-                          , OP_RSHIFT ]
+                          , OP_RSHIFT
+                          , OP_VERIF
+                          , OP_VERNOTIF ]
 
 -- | A trivial `SigCheck` always reporting False
 rejectSignature :: SigCheck

--- a/Network/Haskoin/Script/Evaluator.hs
+++ b/Network/Haskoin/Script/Evaluator.hs
@@ -101,7 +101,7 @@ instance Show Program where
 type ProgramState = ErrorT EvalError Identity
 type IfStack = [ Bool ]
 
--- | Monad of actions idependant of conditional statements.
+-- | Monad of actions independent of conditional statements.
 type ProgramTransition = StateT Program ProgramState
 -- | Monad of actions which taking if statements into account.
 -- Separate state type from ProgramTransition for type safety

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -90,11 +90,9 @@ tests =
     , testFile "Canonical Valid Script Test Cases"
                "tests/data/script_valid.json"
                True
-    {-
     , testFile "Canonical Invalid Script Test Cases"
                "tests/data/script_invalid.json"
                False
-    -}
     ]
 
 metaGetPut :: (Binary a, Eq a) => a -> Bool

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -269,33 +269,38 @@ testFile label path expected = buildTest $ do
                     (_, Left e) -> fail $ "can't parse key: " ++ show pubKey
                                           ++ " error: " ++ e
                     (Right scriptSig, Right scriptPubKey) ->
-                        check $ execScript scriptSig scriptPubKey rejectSignature
-                        where check (Left err) =
-                                  HUnit.assertFailure $ "error: " ++ show err
-                              check (Right p) =
-                                  let x = checkStack . runStack $ p
-                                  in HUnit.assertBool
-                                     ("unexpected eval result: " ++ (show x))
-                                     (expected == x)
+                        runTest scriptSig scriptPubKey
 
-                    where label' = "sig: [" ++ sig ++ "] " ++
-                                   " pubKey: [" ++ pubKey ++ "] " ++
-                                   (if null label
-                                        then ""
-                                        else " label: " ++ label)
+                where label' = "sig: [" ++ sig ++ "] " ++
+                               " pubKey: [" ++ pubKey ++ "] " ++
+                               (if null label
+                                    then ""
+                                    else " label: " ++ label)
 
+            runTest scriptSig scriptPubKey =
+                if expected == run evalScript
+                  then HUnit.assertBool "expected result" True
+                  else HUnit.assertFailure $
+                       "unexpected result " ++ (show $ not expected) ++
+                       " error: " ++ errorMessage
 
+                where run f = f scriptSig scriptPubKey rejectSignature
+                      errorMessage = case run execScript of
+                        Left e -> show e
+                        Right _ -> " none"
 
 
 -- repl utils
 
-execScriptIO :: String -> IO ()
-execScriptIO s = case parseScript s of
-  Left e -> print $ "parse error: " ++ e
-  Right s -> case execScript emptyScript s rejectSignature of
-                  Left e -> putStrLn $ "error " ++ show e
-                  Right p -> do putStrLn $ "successful execution"
-                                putStrLn $ dumpStack $ runStack p
+execScriptIO :: String -> String -> IO ()
+execScriptIO sig key = case (parseScript sig, parseScript key) of
+  (Left e, _) -> print $ "sig parse error: " ++ e
+  (_, Left e) -> print $ "key parse error: " ++ e
+  (Right scriptSig, Right scriptPubKey) ->
+      case execScript scriptSig scriptPubKey rejectSignature of
+          Left e -> putStrLn $ "error " ++ show e
+          Right p -> do putStrLn $ "successful execution"
+                        putStrLn $ dumpStack $ runStack p
 
 
 testValid = testFile "Canonical Valid Script Test Cases"

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -283,7 +283,7 @@ testFile label path expected = buildTest $ do
 
             runTest label scriptSig scriptPubKey =
                 HUnit.assertBool
-                  (label ++ " eval error: " ++ errorMessage)
+                  (" eval error: " ++ errorMessage)
                   (expected == run evalScript)
 
                 where run f = f scriptSig scriptPubKey rejectSignature


### PR DESCRIPTION
Down to one failing test now

``` text
> runTests [testValid]
Canonical Valid Script Test Cases:

         Test Cases    Total        
 Passed  434           434          
 Failed  0             0            
 Total   434           434          
*** Exception: ExitSuccess
*Network.Haskoin.Script.Tests


> runTests [testInvalid]
Canonical Valid Script Test Cases:
  sig: [2147483647 DUP ADD]  pubKey: [4294967294 NUMEQUAL]  
  label: NUMEQUAL must be in numeric range: [Failed]
 eval error:  none

         Test Cases    Total        
 Passed  291           291          
 Failed  1             1            
 Total   292           292          
*** Exception: ExitFailure 1
*Network.Haskoin.Script.Tests
> 
```
