### PR TITLE
Fix warnings

### DIFF
--- a/Network/Haskoin/Script/Evaluator.hs
+++ b/Network/Haskoin/Script/Evaluator.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, PatternGuards #-}
+{-# LANGUAGE LambdaCase #-}
 {-|
 
 Module providing Bitcoin script evaluation.  See
@@ -41,7 +41,7 @@ import Data.Bits (shiftR, shiftL, testBit, setBit, clearBit)
 import Data.Int (Int64)
 import Data.Word (Word8, Word64)
 import Data.Either ( rights )
-import Data.Maybe ( catMaybes )
+import Data.Maybe ( mapMaybe, isJust )
 
 import Network.Haskoin.Crypto
 import Network.Haskoin.Script.Types
@@ -76,9 +76,9 @@ instance Error EvalError where
 
 instance Show EvalError where
     show (EvalError m) = m
-    show (ProgramError m prog) = m ++ " - program: " ++ (show prog)
-    show (StackError op) = (show op) ++ ": Stack Error"
-    show (DisabledOp op) = (show op) ++ ": disabled"
+    show (ProgramError m prog) = m ++ " - program: " ++ show prog
+    show (StackError op) = show op ++ ": Stack Error"
+    show (DisabledOp op) = show op ++ ": disabled"
 
 type StackValue = [Word8]
 type AltStack = [StackValue]
@@ -100,12 +100,12 @@ data Program = Program {
 
 dumpOp :: ScriptOp -> String
 dumpOp (OP_PUSHDATA payload optype) =
-  "OP_PUSHDATA(" ++ (show optype) ++ ")" ++
-  " 0x" ++ (bsToHex payload)
+  "OP_PUSHDATA(" ++ show optype ++ ")" ++
+  " 0x" ++ bsToHex payload
 dumpOp op = show op
 
 dumpList :: [String] -> String
-dumpList xs = "[" ++ (intercalate "," xs) ++ "]"
+dumpList xs = "[" ++ intercalate "," xs ++ "]"
 
 dumpScript :: [ScriptOp] -> String
 dumpScript script = dumpList $ map dumpOp script
@@ -114,7 +114,7 @@ dumpStack :: Stack -> String
 dumpStack s = dumpList $ map (bsToHex . BS.pack) s
 
 instance Show Program where
-    show p = " stack: " ++ (dumpStack $ stack p)
+    show p = " stack: " ++ dumpStack (stack p)
 
 type ProgramState = ErrorT EvalError Identity
 type IfStack = [ Bool ]
@@ -132,7 +132,7 @@ evalConditionalProgram :: ConditionalProgramTransition a -- ^ Program monad
                        -> [ Bool ]                       -- ^ Initial if state stack
                        -> Program                        -- ^ Initial computation data
                        -> Either EvalError a
-evalConditionalProgram m s p = evalProgramTransition ( evalStateT m s ) p
+evalConditionalProgram m s = evalProgramTransition ( evalStateT m s )
 
 --------------------------------------------------------------------------------
 -- Error utils
@@ -152,11 +152,11 @@ encodeInt :: Int64 -> StackValue
 encodeInt i = prefix $ encode' (fromIntegral $ abs i) []
     where encode' :: Word64 -> StackValue -> StackValue
           encode' 0 bytes = bytes
-          encode' j bytes = (fromIntegral j):(encode' (j `shiftR` 8) bytes)
+          encode' j bytes = fromIntegral j:encode' (j `shiftR` 8) bytes
           prefix :: StackValue -> StackValue
           prefix [] = []
           prefix xs | testBit (last xs) 7 = prefix $ xs ++ [0]
-                    | i < 0 = (init xs) ++ [setBit (last xs) 7]
+                    | i < 0 = init xs ++ [setBit (last xs) 7]
                     | otherwise = xs
 
 -- | Inverse of `encodeInt`.
@@ -164,8 +164,8 @@ decodeInt :: StackValue -> Int64
 decodeInt bytes = sign' (decodeW bytes)
     where decodeW [] = 0
           decodeW [x] = fromIntegral $ clearBit x 7
-          decodeW (x:xs) = (fromIntegral x) + (decodeW xs) `shiftL` 8
-          sign' i | bytes == [] = 0
+          decodeW (x:xs) = fromIntegral x + decodeW xs `shiftL` 8
+          sign' i | null bytes = 0
                   | testBit (last bytes) 7 = -i
                   | otherwise = i
 
@@ -203,7 +203,7 @@ constValue op = case op of
 
 -- | Check if OpCode is constant
 isConstant :: ScriptOp -> Bool
-isConstant op = Nothing /= constValue op
+isConstant = isJust . constValue
 
 -- | Check if OpCode is disabled
 isDisabled :: ScriptOp -> Bool
@@ -235,7 +235,7 @@ countOp op | isConstant op     = False
 
 popInt :: ProgramTransition Int64
 popInt = popStack >>= \sv ->
-    if (length sv) > 4 then
+    if length sv > 4 then
         programError $ "integer > nMaxNumSize: " ++ show (length sv)
     else
         return $ decodeInt sv
@@ -289,8 +289,7 @@ prependStack s = getStack >>= \s' -> putStack $ s ++ s'
 
 checkPushData :: ScriptOp -> ProgramTransition ()
 checkPushData (OP_PUSHDATA v _) | BS.length v > fromIntegral maxScriptElementSize
-                                  = programError $
-                                    "OP_PUSHDATA > maxScriptElementSize"
+                                  = programError "OP_PUSHDATA > maxScriptElementSize"
                                 | otherwise = return ()
 checkPushData _ = return ()
 
@@ -298,7 +297,7 @@ checkStackSize :: ProgramTransition ()
 checkStackSize = do n <- length <$> stack <$> get
                     m <- length <$> altStack <$> get
                     when ((n + m) > fromIntegral maxStackSize) $
-                         programError $ "stack > maxStackSize"
+                         programError "stack > maxStackSize"
 
 pushStack :: StackValue -> ProgramTransition ()
 pushStack v = getStack >>= \s -> putStack (v:s)
@@ -308,7 +307,7 @@ popStack = withStack >>= \(s:ss) -> putStack ss >> return s
 
 popStackN :: Integer -> ProgramTransition [StackValue]
 popStackN 0 = return []
-popStackN n = (:) <$> popStack <*> (popStackN (n - 1))
+popStackN n = (:) <$> popStack <*> popStackN (n - 1)
 
 pickStack :: Bool -> Int -> ProgramTransition ()
 pickStack remove n = do
@@ -348,7 +347,7 @@ preparedHashOps = filter ( /= OP_CODESEPARATOR ) <$> getHashOps
 -- scripts.  See FindAndDelete() in Bitcoin Core.
 findAndDelete :: [ StackValue ] -> [ ScriptOp ] -> [ ScriptOp ]
 findAndDelete [] ops = ops
-findAndDelete (s:ss) ops = let pushOp = opPushData . opToSv $ s in 
+findAndDelete (s:ss) ops = let pushOp = opPushData . opToSv $ s in
   findAndDelete ss $ filter ( /= pushOp ) ops
 
 checkMultiSig :: SigCheck -- ^ Signature checking function
@@ -356,13 +355,12 @@ checkMultiSig :: SigCheck -- ^ Signature checking function
               -> [ StackValue ] -- ^ Signatures
               -> [ ScriptOp ]   -- ^ CODESEPARATOR'd hashops
               -> Bool
-checkMultiSig f encPubKeys encSigs hOps = 
-  let pubKeys = catMaybes $ map ( decodeToMaybe . opToSv ) encPubKeys
+checkMultiSig f encPubKeys encSigs hOps =
+  let pubKeys = mapMaybe ( decodeToMaybe . opToSv ) encPubKeys
       sigs = rights $ map ( decodeSig . opToSv ) encSigs
       cleanHashOps = findAndDelete encSigs hOps
-  in if length sigs < length encSigs
-    then False -- A bad signature exists.
-    else orderedSatisfy (f cleanHashOps) sigs pubKeys
+  in (length sigs == length encSigs) && -- check for bad signatures
+     orderedSatisfy (f cleanHashOps) sigs pubKeys
 
 -- | Tests whether a function is satisfied for every a with some b "in
 -- order".  By "in order" we mean, if a pair satisfies the function,
@@ -376,10 +374,9 @@ orderedSatisfy :: ( a -> b -> Bool )
                     -> Bool
 orderedSatisfy _ [] _ = True
 orderedSatisfy _ (_:_) [] = False
-orderedSatisfy f x@(a:as) y@(b:bs) = if length x > length y then False
-  else case f a b of
-    False -> orderedSatisfy f x bs
-    True -> orderedSatisfy f as bs
+orderedSatisfy f x@(a:as) y@(b:bs) | length x > length y = False
+                                   | f a b     = orderedSatisfy f as bs
+                                   | otherwise = orderedSatisfy f x bs
 
 tStack1 :: (StackValue -> Stack) -> ProgramTransition ()
 tStack1 f = f <$> popStack >>= prependStack
@@ -417,7 +414,7 @@ stackError = programError "stack error"
 -- AltStack Primitives
 
 pushAltStack :: StackValue -> ProgramTransition ()
-pushAltStack op = modify $ \p -> p { altStack = op:(altStack p) }
+pushAltStack op = modify $ \p -> p { altStack = op:altStack p }
 
 popAltStack :: ProgramTransition StackValue
 popAltStack = get >>= \p -> case altStack p of
@@ -426,7 +423,7 @@ popAltStack = get >>= \p -> case altStack p of
 
 
 incrementOpCount :: Int -> ProgramTransition ()
-incrementOpCount i | i > maxOpcodes = programError $ "reached opcode limit"
+incrementOpCount i | i > maxOpcodes = programError "reached opcode limit"
                    | otherwise      = modify $ \p -> p { opCount = i + 1 }
 
 -- Instruction Evaluation
@@ -478,7 +475,7 @@ eval OP_SIZE   = (fromIntegral . length <$> popStack) >>= pushStack . encodeInt
 -- Bitwise Logic
 
 eval OP_EQUAL   = tStack2 $ \a b -> [encodeBool (a == b)]
-eval OP_EQUALVERIFY = (eval OP_EQUAL) >> (eval OP_VERIFY)
+eval OP_EQUALVERIFY = eval OP_EQUAL >> eval OP_VERIFY
 
 -- Arithmetic
 
@@ -519,13 +516,13 @@ eval OP_CHECKSIG = do
   pushBool $ checkMultiSig checker [ pubKey ] [ sig ] hOps -- Reuse checkMultiSig code
 
 eval OP_CHECKMULTISIG =
-    do pubKeys <- (popInt >>= popStackN . fromIntegral)
+    do pubKeys <- popInt >>= popStackN . fromIntegral
        sigs <- popInt >>= popStackN . fromIntegral
        void popStack -- spec bug
        checker <- sigCheck <$> get
        hOps <- preparedHashOps
        pushBool $ checkMultiSig checker pubKeys sigs hOps
-       modify $ \p -> p { opCount = (opCount p) + (length pubKeys) }
+       modify $ \p -> p { opCount = opCount p + length pubKeys }
 
 eval OP_CHECKSIGVERIFY      = eval OP_CHECKSIG      >> eval OP_VERIFY
 eval OP_CHECKMULTISIGVERIFY = eval OP_CHECKMULTISIG >> eval OP_VERIFY
@@ -551,13 +548,13 @@ conditionalEval scrpOp = do
 
    when (countOp scrpOp) $ lift $ join $ incrementOpCount <$> opCount <$> get
 
-   lift $ checkStackSize
+   lift checkStackSize
 
    where
      eval' :: Bool -> ScriptOp -> ConditionalProgramTransition ()
 
-     eval' True  OP_IF      = ( lift $ popStack ) >>= pushCond . decodeBool
-     eval' True  OP_NOTIF   = ( lift $ popStack ) >>= pushCond . not . decodeBool
+     eval' True  OP_IF      = lift popStack >>= pushCond . decodeBool
+     eval' True  OP_NOTIF   = lift popStack >>= pushCond . not . decodeBool
      eval' True  OP_ELSE    = flipCond
      eval' True  OP_ENDIF   = void popCond
      eval' True  op = lift $ eval op
@@ -593,7 +590,7 @@ checkStack []  = False
 
 isPayToScriptHash :: [ ScriptOp ] -> Bool
 isPayToScriptHash [OP_HASH160, OP_PUSHDATA bytes OPCODE, OP_EQUAL]
-                    = (BS.length bytes) == 20
+                    = BS.length bytes == 20
 isPayToScriptHash _ = False
 
 stackToScriptOps :: StackValue -> [ ScriptOp ]
@@ -621,15 +618,15 @@ execScript scriptSig scriptPubKey sigCheckFcn =
       checkSig | isPayToScriptHash pubKeyOps = checkPushOnly sigOps
                | otherwise = return ()
 
-      checkKey | (BSL.length $ encode scriptPubKey) > fromIntegral maxScriptSize
-                 = lift $ programError $ "pubKey > maxScriptSize"
+      checkKey | BSL.length (encode scriptPubKey) > fromIntegral maxScriptSize
+                 = lift $ programError "pubKey > maxScriptSize"
                | otherwise = return ()
 
 
-      redeemEval = checkSig >> evalAll sigOps >> (lift $ stack <$> get)
-      pubKeyEval = checkKey >> evalAll pubKeyOps >> (lift $ get)
-      p2shEval [] = lift $ programError $ "PayToScriptHash: no script on stack"
-      p2shEval (sv:_) = (evalAll $ stackToScriptOps sv) >> (lift $ get)
+      redeemEval = checkSig >> evalAll sigOps >> lift (stack <$> get)
+      pubKeyEval = checkKey >> evalAll pubKeyOps >> lift get
+      p2shEval [] = lift $ programError "PayToScriptHash: no script on stack"
+      p2shEval (sv:_) = evalAll (stackToScriptOps sv) >> lift get
 
       in do s <- evalConditionalProgram redeemEval [] emptyProgram
             p <- evalConditionalProgram pubKeyEval [] emptyProgram { stack = s }
@@ -659,7 +656,7 @@ verifySpend :: Tx     -- ^ The spending transaction
             -> Int    -- ^ The input index
             -> Script -- ^ The output script we are spending
             -> Bool
-verifySpend tx i outscript = 
+verifySpend tx i outscript =
   let scriptSig = decode' . scriptInput $ txIn tx !! i
       verifyFcn = verifySigWithType tx i
   in

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -28,14 +28,13 @@ import qualified Data.ByteString as BS
     )
 
 import qualified Data.ByteString.Lazy as LBS
-    ( singleton
-    , pack
+    ( pack
     , unpack
     )
 
 import Data.Maybe (catMaybes)
 
-import Data.Binary (encode, decode, decodeOrFail)
+import Data.Binary (encode, decodeOrFail)
 
 import qualified Data.ByteString.Lazy.Char8 as C (readFile)
 
@@ -166,22 +165,15 @@ testEncodeBool b = (decodeBool $ encodeBool b) == b
 
 {- Script Evaluation -}
 
-emptyScript :: Script
-emptyScript = Script { scriptOps = [] }
-
 rejectSignature :: SigCheck
 rejectSignature _ _ _ = False
-
 
 {- Parse tests from bitcoin-qt repository -}
 
 type ParseError = String
 
-decodeByte :: Word8 -> Maybe ScriptOp
-decodeByte = decode . LBS.singleton
-
 parseHex' :: String -> Maybe [Word8]
-parseHex' (a:b:xs) = case readHex $ [a, b] of
+parseHex' (a:b:xs) = case readHex $ [a, b] :: [(Integer, String)] of
                       [(i, "")] -> case parseHex' xs of
                                     Just ops -> Just $ fromIntegral i:ops
                                     Nothing -> Nothing
@@ -213,7 +205,8 @@ parseScript script =
                                               ]
                     parseHex | "0x" `isPrefixOf` tok = parseHex' (drop 2 tok)
                              | otherwise = Nothing
-                    parseInt = fromInt . fromIntegral <$> (readMaybe tok)
+                    parseInt = fromInt . fromIntegral <$>
+                               (readMaybe tok :: Maybe Integer)
                     parseQuote | tok == "''" = Just [0]
                                | (head tok) == '\'' && (last tok) == '\'' =
                                  Just $ encodeBytes $ opPushData $ BS.pack
@@ -231,13 +224,13 @@ parseScript script =
                     encodeBytes = LBS.unpack . encode
 
 testFile :: String -> String -> Bool -> Test
-testFile label path expected = buildTest $ do
+testFile groupLabel path expected = buildTest $ do
     dat <- C.readFile path
     case (A.decode dat) :: Maybe [[String]] of
         Nothing -> return $
-                    testCase label $
+                    testCase groupLabel $
                     HUnit.assertFailure $ "can't read test file " ++ path
-        Just tests -> return $ testGroup label $ map parseTest tests
+        Just testDefs -> return $ testGroup groupLabel $ map parseTest testDefs
 
     where   parseTest :: [String] -> Test
             parseTest (sig:pubKey:[])       = makeTest "" sig pubKey
@@ -255,7 +248,7 @@ testFile label path expected = buildTest $ do
                     (_, Left e) -> parseError $ "can't parse key: " ++
                                                 show pubKey ++ " error: " ++ e
                     (Right scriptSig, Right scriptPubKey) ->
-                        runTest label' scriptSig scriptPubKey
+                        runTest scriptSig scriptPubKey
 
                 where label' = "sig: [" ++ sig ++ "] " ++
                                " pubKey: [" ++ pubKey ++ "] " ++
@@ -267,7 +260,7 @@ testFile label path expected = buildTest $ do
                                 ("parse error in valid script: " ++ message)
                                 (expected == False)
 
-            runTest label scriptSig scriptPubKey =
+            runTest scriptSig scriptPubKey =
                 HUnit.assertBool
                   (" eval error: " ++ errorMessage)
                   (expected == run evalScript)
@@ -297,4 +290,5 @@ testValid = testFile "Canonical Valid Script Test Cases"
 testInvalid = testFile "Canonical Valid Script Test Cases"
               "tests/data/script_invalid.json" False
 
-runTests tests = defaultMainWithArgs tests ["--hide-success"]
+runTests :: [Test] -> IO ()
+runTests ts = defaultMainWithArgs ts ["--hide-success"]

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -9,36 +9,26 @@ import Test.Framework.Runners.Console (defaultMainWithArgs)
 
 import qualified Test.HUnit as HUnit
 
-import Control.Applicative ((<$>), (<*>))
+import Control.Applicative ((<$>))
 
-import Numeric (showHex, readHex)
+import Numeric (readHex)
 
 import qualified Data.Aeson as A (decode)
 import Data.Bits (setBit, testBit)
 import Text.Read (readMaybe)
 import Data.Binary (Binary, Word8)
-import Data.List.Split (splitOn)
-import Data.List (isPrefixOf, isSuffixOf, intercalate, intersect)
+import Data.List (isPrefixOf)
 import Data.Char (ord)
 import qualified Data.ByteString as BS
-    ( ByteString
-    , singleton
+    ( singleton
     , length
     , tail
     , head
     , pack
-    , unpack
     )
 
-import qualified Data.ByteString.Builder as BSB
-    ( toLazyByteString
-    , byteStringHex
-    , word8
-    )
-
-import qualified Data.ByteString.Lazy as LBS 
-    ( ByteString
-    , singleton
+import qualified Data.ByteString.Lazy as LBS
+    ( singleton
     , pack
     , unpack
     )
@@ -56,7 +46,6 @@ import Network.Haskoin.Script.Arbitrary
 
 import Network.Haskoin.Script
 import Network.Haskoin.Script.Evaluator
-import Network.Haskoin.Script.Types
 import Network.Haskoin.Crypto
 import Network.Haskoin.Protocol
 import Network.Haskoin.Util


### PR DESCRIPTION
Fixes most of the warnings in `Evaluator.hs` and corresponding `Tests.hs` (Issue #69)

`Tests.hs` still contains some useful functions I use from `cabal repl` during development -- any idea where to put them else?
