### PR TITLE
Fix of PayToSH logic in Evaluator.hs

### DIFF
--- a/Network/Haskoin/Script/Evaluator.hs
+++ b/Network/Haskoin/Script/Evaluator.hs
@@ -630,8 +630,9 @@ execScript scriptSig scriptPubKey sigCheckFcn =
 
       in do s <- evalConditionalProgram redeemEval [] emptyProgram
             p <- evalConditionalProgram pubKeyEval [] emptyProgram { stack = s }
-            if isPayToScriptHash pubKeyOps
-                then evalConditionalProgram (p2shEval s) [] emptyProgram
+            if ( checkStack . runStack $ p ) &&  ( isPayToScriptHash pubKeyOps ) && ( not . null $ s )
+                then evalConditionalProgram (p2shEval s) [] emptyProgram { stack = drop 1 s,
+                                                                           hashOps = stackToScriptOps $ head s }
                 else return p
 
 evalScript :: Script -> Script -> SigCheck -> Bool


### PR DESCRIPTION
A couple of bug fixes in the p2sh logic.
- Added more checking on whether the redeemScript should be evaluated
  (no empty stack, scriptPubKey had success)
- Changed the starting program state to be what is required ( need the scriptSig
  ending stack minus the redeemScript, and hashOps needs to be the redeemScript)

Admittedly, this fix is a bit of a kludge.  Some clean-up or refactoring of the area is probably a good idea, but I wanted to get the fix in.
