### PR TITLE
Util: improve bsToHex performance

### DIFF
--- a/Network/Haskoin/Util.hs
+++ b/Network/Haskoin/Util.hs
@@ -97,6 +97,10 @@ import qualified Data.ByteString as BS
     , foldl'
     , null
     )
+import qualified Data.ByteString.Builder as BSB
+    ( toLazyByteString
+    , byteStringHex
+    )
 import qualified Data.ByteString.Char8 as C
     ( pack
     , unpack
@@ -140,7 +144,7 @@ integerToBS i
 
 -- | Encode a bytestring to a base16 (HEX) representation
 bsToHex :: BS.ByteString -> String
-bsToHex = BS.foldl' (\a x -> mappend a (printf "%02x" x)) ""
+bsToHex = bsToString . toStrictBS . BSB.toLazyByteString . BSB.byteStringHex
 
 -- | Decode a base16 (HEX) string from a bytestring. This function can fail
 -- if the string contains invalid HEX characters


### PR DESCRIPTION
The old routine is very slow for larger inputs, something O(n^2):

```
> length $ bsToHex $ BS.pack $ take 3000 (repeat 0x62)
6000
(1.01 secs, 662956664 bytes)

> length $ bsToHex $ BS.pack $ take 6000 (repeat 0x62)
12000
(4.89 secs, 2993737936 bytes)
```

The new method is considerably faster:

```
> length $ bsToHex $ BS.pack $ take 6000000 (repeat 0x62)
12000000
(0.72 secs, 653576448 bytes)
```
