### PR TITLE
Adding a cabal flag for compiling haskoin against testnet

### DIFF
--- a/Network/Haskoin/Crypto/Base58.hs
+++ b/Network/Haskoin/Crypto/Base58.hs
@@ -34,6 +34,7 @@ import qualified Data.Text as T
 
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Constants
 import Network.Haskoin.Util 
 
 b58Data :: BS.ByteString

--- a/Network/Haskoin/Crypto/ECDSA.hs
+++ b/Network/Haskoin/Crypto/ECDSA.hs
@@ -38,6 +38,7 @@ import qualified Data.ByteString as BS
     )
   
 import Network.Haskoin.Util 
+import Network.Haskoin.Constants
 import Network.Haskoin.Crypto.Hash 
 import Network.Haskoin.Crypto.Keys 
 import Network.Haskoin.Crypto.Point 

--- a/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -41,6 +41,7 @@ import Data.Maybe (mapMaybe)
 import qualified Data.ByteString as BS (ByteString, append)
 
 import Network.Haskoin.Util
+import Network.Haskoin.Constants
 import Network.Haskoin.Crypto.Keys
 import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Crypto.Base58

--- a/Network/Haskoin/Crypto/Hash.hs
+++ b/Network/Haskoin/Crypto/Hash.hs
@@ -29,8 +29,6 @@ module Network.Haskoin.Crypto.Hash
 , txHash
 , cbHash
 , headerHash
-, encodeTxHashLE
-, decodeTxHashLE
 ) where
 
 import Control.Monad (replicateM)
@@ -68,7 +66,6 @@ import qualified Data.ByteString as BS
     , length
     , replicate
     , drop
-    , reverse
     )
 
 import Network.Haskoin.Util 
@@ -198,17 +195,6 @@ encodeCompact i
     (s2,c2) | c1 .&. 0x00800000 /= 0  = (s1 + 1, c1 `shiftR` 8)
             | otherwise               = (s1, c1)
     c3 = fromIntegral $ c2 .|. ((toInteger s2) `shiftL` 24)
-
--- | Encodes a transaction hash as little endian in HEX format.
--- This is mostly used for displaying transaction ids. Internally, these ids
--- are handled as big endian but are transformed to little endian when
--- displaying them.
-encodeTxHashLE :: TxHash -> String
-encodeTxHashLE = bsToHex . BS.reverse .  encode' 
-
--- | Decodes a little endian transaction hash in HEX format. 
-decodeTxHashLE :: String -> Maybe TxHash
-decodeTxHashLE = (decodeToMaybe . BS.reverse =<<) . hexToBS
 
 -- | Computes the hash of a transaction.
 txHash :: Tx -> TxHash

--- a/Network/Haskoin/Crypto/Keys.hs
+++ b/Network/Haskoin/Crypto/Keys.hs
@@ -40,6 +40,7 @@ import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.Point 
 import Network.Haskoin.Crypto.Base58 
 import Network.Haskoin.Crypto.Hash 
+import Network.Haskoin.Constants
 import Network.Haskoin.Util 
 
 -- | G parameter of the EC curve expressed as a Point

--- a/Network/Haskoin/Crypto/Merkle.hs
+++ b/Network/Haskoin/Crypto/Merkle.hs
@@ -14,6 +14,7 @@ import qualified Data.ByteString as BS
 import Network.Haskoin.Crypto.Hash
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Util
+import Network.Haskoin.Constants
 
 type MerkleRoot        = Word256
 type FlagBits          = [Bool]

--- a/Network/Haskoin/Protocol/Message.hs
+++ b/Network/Haskoin/Protocol/Message.hs
@@ -30,6 +30,7 @@ import Network.Haskoin.Protocol.Types
 
 import Network.Haskoin.Util 
 import Network.Haskoin.Crypto.Hash 
+import Network.Haskoin.Constants
 
 -- | Data type representing the header of a 'Message'. All messages sent between
 -- nodes contain a message header.

--- a/Network/Haskoin/Protocol/Types.hs
+++ b/Network/Haskoin/Protocol/Types.hs
@@ -40,8 +40,10 @@ import Control.DeepSeq (NFData, rnf)
 import Control.Monad (liftM2, replicateM, forM_, unless)
 import Control.Applicative ((<$>),(<*>))
 
+import Data.Aeson (Value(String), FromJSON, ToJSON, parseJSON, toJSON, withText)
 import Data.Bits (testBit, setBit)
 import Data.Word (Word8, Word16, Word32, Word64)
+import qualified Data.Text as T
 import Data.Binary (Binary, get, put)
 import Data.Binary.Get 
     ( Get
@@ -723,6 +725,13 @@ instance Binary Tx where
         put $ VarInt $ fromIntegral $ length os
         forM_ os put
         putWord32le l
+
+instance FromJSON Tx where
+    parseJSON = withText "transaction" $ \t -> either fail return $
+        maybeToEither "tx not hex" (hexToBS $ T.unpack t) >>= decodeToEither
+
+instance ToJSON Tx where
+    toJSON = String . T.pack . bsToHex . encode'
 
 -- | Data type representing the coinbase transaction of a 'Block'. Coinbase
 -- transactions are special types of transactions which are created by miners

--- a/Network/Haskoin/Protocol/Types.hs
+++ b/Network/Haskoin/Protocol/Types.hs
@@ -862,6 +862,14 @@ data OutPoint =
 instance NFData OutPoint where
     rnf (OutPoint h i) = rnf h `seq` rnf i
 
+instance FromJSON OutPoint where
+    parseJSON = withText "outpoint" $ \t -> either fail return $
+        maybeToEither "outpoint not hex" 
+          (hexToBS $ T.unpack t) >>= decodeToEither
+
+instance ToJSON OutPoint where
+    toJSON = String . T.pack . bsToHex . encode'
+
 instance Binary OutPoint where
     get = do
         (h,i) <- liftM2 (,) get getWord32le

--- a/Network/Haskoin/Script/Parser.hs
+++ b/Network/Haskoin/Script/Parser.hs
@@ -47,7 +47,6 @@ import Data.Aeson
     , toJSON
     , withText
     )
-
 import Network.Haskoin.Util
 import Network.Haskoin.Crypto.Keys
 import Network.Haskoin.Crypto.Base58

--- a/Network/Haskoin/Script/Parser.hs
+++ b/Network/Haskoin/Script/Parser.hs
@@ -33,10 +33,19 @@ import Control.Applicative ((<$>), (<|>))
 
 import Data.List (sortBy)
 import Data.Foldable (foldrM)
+import qualified Data.Text as T
 import qualified Data.ByteString as BS 
     ( ByteString
     , head
     , singleton
+    )
+import Data.Aeson
+    ( Value (String)
+    , FromJSON
+    , ToJSON
+    , parseJSON
+    , toJSON
+    , withText
     )
 
 import Network.Haskoin.Util
@@ -61,6 +70,14 @@ data ScriptOutput =
       -- | Pay to a script hash.
     | PayScriptHash { getOutputAddress  :: !Address }
     deriving (Eq, Show, Read)
+
+instance FromJSON ScriptOutput where
+    parseJSON = withText "scriptoutput" $ \t -> either fail return $
+        maybeToEither "scriptoutput not hex" 
+          (hexToBS $ T.unpack t) >>= decodeOutputBS
+
+instance ToJSON ScriptOutput where
+    toJSON = String . T.pack . bsToHex . encodeOutputBS
 
 instance NFData ScriptOutput where
     rnf (PayPK k) = rnf k

--- a/Network/Haskoin/Util.hs
+++ b/Network/Haskoin/Util.hs
@@ -46,17 +46,6 @@ module Network.Haskoin.Util
 , snd3
 , lst3
 
-  -- *Constants
-, addrPrefix
-, scriptPrefix
-, secretPrefix
-, extPubKeyPrefix
-, extSecretPrefix
-, networkMagic
-, genesisHeader
-, maxBlockSize
-, haskoinUserAgent
-
 ) where
 
 import Numeric (readHex)
@@ -102,8 +91,6 @@ import qualified Data.ByteString.Char8 as C
     ( pack
     , unpack
     )
-
-import Network.Haskoin.Util.Constants
 
 -- ByteString helpers
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@ You can install the latest stable version of the haskoin package automatically
 through the cabal package manager:
 
 ```sh
-# Install
+# Compile for prodnet 
 cabal install haskoin
+
+# Compile for testnet
+cabal install haskoin --flags=testnet
 ```
 
 ## Contributing
 
 Commits are done through GitHub pull requests.
 
-We do a lot of our technical discussions at the IRC channel #haskoin on
+We do a lot of our technical discussions in the IRC channel #haskoin on
 chat.freenode.net.
 
 Code guidelines:

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -23,6 +23,9 @@ source-repository head
     type:     git
     location: git://github.com/haskoin/haskoin.git
 
+Flag Testnet
+    Description: Compile the library against Testnet instead of Prodnet
+    Default:     False
 
 library
     exposed-modules:   Network.Haskoin.Util,
@@ -30,10 +33,9 @@ library
                        Network.Haskoin.Crypto,
                        Network.Haskoin.Protocol,
                        Network.Haskoin.Script,
-                       Network.Haskoin.Transaction
-    other-modules:     Network.Haskoin.Util.Constants,
-                       Network.Haskoin.Util.Constants.Testnet,
-                       Network.Haskoin.Crypto.NumberTheory, 
+                       Network.Haskoin.Transaction,
+                       Network.Haskoin.Constants
+    other-modules:     Network.Haskoin.Crypto.NumberTheory, 
                        Network.Haskoin.Crypto.Curve, 
                        Network.Haskoin.Crypto.Hash, 
                        Network.Haskoin.Crypto.BigWord,
@@ -77,6 +79,10 @@ library
                        text                 >= 1.1 && < 1.2,
                        vector               >= 0.10 && < 0.11
     ghc-options:       -Wall -fno-warn-orphans
+  if flag(testnet)
+    hs-source-dirs:    . testnet
+  else
+    hs-source-dirs:    . prodnet
 
 test-suite test-haskoin
     type:              exitcode-stdio-1.0
@@ -136,6 +142,9 @@ test-suite test-haskoin
                        test-framework             >= 0.8  && < 0.9, 
                        test-framework-quickcheck2 >= 0.3  && < 0.4, 
                        test-framework-hunit       >= 0.3  && < 0.4 
-    hs-source-dirs:    . tests
     ghc-options:       -Wall -fno-warn-orphans
+  if flag(testnet)
+    hs-source-dirs:    . tests testnet
+  else
+    hs-source-dirs:    . tests prodnet
 

--- a/prodnet/Network/Haskoin/Constants.hs
+++ b/prodnet/Network/Haskoin/Constants.hs
@@ -53,3 +53,6 @@ maxBlockSize = 1000000
 haskoinUserAgent :: String
 haskoinUserAgent = "/haskoin:0.0.2.1/"
 
+defaultPort :: Int
+defaultPort = 8333
+

--- a/prodnet/Network/Haskoin/Constants.hs
+++ b/prodnet/Network/Haskoin/Constants.hs
@@ -5,6 +5,10 @@ module Network.Haskoin.Constants where
 
 import Data.Word (Word8,Word32)
 
+-- | Name of the bitcoin network
+networkName :: String
+networkName = "prodnet"
+
 -- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
 addrPrefix = 0

--- a/prodnet/Network/Haskoin/Constants.hs
+++ b/prodnet/Network/Haskoin/Constants.hs
@@ -1,44 +1,44 @@
 {-|
-  Declaration of constants used across the testnet bitcoin protocol
+  Declaration of constants used across the bitcoin protocol.
 -}
-module Network.Haskoin.Util.Constants.Testnet where
+module Network.Haskoin.Constants where
 
 import Data.Word (Word8,Word32)
 
 -- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
-addrPrefix = 111
+addrPrefix = 0
 
 -- | Prefix for base58 script hash address
 scriptPrefix :: Word8
-scriptPrefix = 196
+scriptPrefix = 5
 
 -- | Prefix for private key WIF format
 secretPrefix :: Word8
-secretPrefix = 239
+secretPrefix = 128
 
 -- | Prefix for extended public keys (BIP32)
 extPubKeyPrefix :: Word32
-extPubKeyPrefix = 0x043587cf
+extPubKeyPrefix = 0x0488b21e
 
 -- | Prefix for extended private keys (BIP32)
 extSecretPrefix :: Word32
-extSecretPrefix = 0x04358394
+extSecretPrefix = 0x0488ade4
 
 -- | Network magic bytes
 networkMagic :: Word32
-networkMagic = 0x0b110907 
+networkMagic = 0xf9beb4d9 
 
 -- | Genesis block header information
 genesisHeader :: [Integer]
 genesisHeader =
-    -- Hash = 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
+    -- Hash = 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
     [ 0x01
     , 0x00
     , 0x3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a
-    , 1296688602
+    , 1231006505
     , 486604799
-    , 414098458
+    , 2083236893
     ]
 
 -- | Maximum size of a block in bytes

--- a/testnet/Network/Haskoin/Constants.hs
+++ b/testnet/Network/Haskoin/Constants.hs
@@ -5,6 +5,10 @@ module Network.Haskoin.Constants where
 
 import Data.Word (Word8,Word32)
 
+-- | Name of the bitcoin network
+networkName :: String
+networkName = "testnet"
+
 -- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
 addrPrefix = 111

--- a/testnet/Network/Haskoin/Constants.hs
+++ b/testnet/Network/Haskoin/Constants.hs
@@ -1,44 +1,44 @@
 {-|
-  Declaration of constants used across the bitcoin protocol.
+  Declaration of constants used across the testnet bitcoin protocol
 -}
-module Network.Haskoin.Util.Constants where
+module Network.Haskoin.Constants where
 
 import Data.Word (Word8,Word32)
 
 -- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
-addrPrefix = 0
+addrPrefix = 111
 
 -- | Prefix for base58 script hash address
 scriptPrefix :: Word8
-scriptPrefix = 5
+scriptPrefix = 196
 
 -- | Prefix for private key WIF format
 secretPrefix :: Word8
-secretPrefix = 128
+secretPrefix = 239
 
 -- | Prefix for extended public keys (BIP32)
 extPubKeyPrefix :: Word32
-extPubKeyPrefix = 0x0488b21e
+extPubKeyPrefix = 0x043587cf
 
 -- | Prefix for extended private keys (BIP32)
 extSecretPrefix :: Word32
-extSecretPrefix = 0x0488ade4
+extSecretPrefix = 0x04358394
 
 -- | Network magic bytes
 networkMagic :: Word32
-networkMagic = 0xf9beb4d9 
+networkMagic = 0x0b110907 
 
 -- | Genesis block header information
 genesisHeader :: [Integer]
 genesisHeader =
-    -- Hash = 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    -- Hash = 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
     [ 0x01
     , 0x00
     , 0x3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a
-    , 1231006505
+    , 1296688602
     , 486604799
-    , 2083236893
+    , 414098458
     ]
 
 -- | Maximum size of a block in bytes
@@ -47,5 +47,5 @@ maxBlockSize = 1000000
 
 -- | User agent of this haskoin package
 haskoinUserAgent :: String
-haskoinUserAgent = "/haskoin:0.0.2.1/"
+haskoinUserAgent = "/haskoin-testnet:0.0.2.1/"
 

--- a/testnet/Network/Haskoin/Constants.hs
+++ b/testnet/Network/Haskoin/Constants.hs
@@ -53,3 +53,6 @@ maxBlockSize = 1000000
 haskoinUserAgent :: String
 haskoinUserAgent = "/haskoin-testnet:0.0.2.1/"
 
+defaultPort :: Int
+defaultPort = 18333
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -39,6 +39,9 @@ import qualified Network.Haskoin.Transaction.Units (tests)
 -- Stratum tests
 import qualified Network.Haskoin.Stratum.Units (tests)
 
+-- Json tests
+import qualified Network.Haskoin.Json.Tests (tests)
+
 main :: IO ()
 main = defaultMain
     (  Network.Haskoin.Util.Tests.tests
@@ -66,5 +69,6 @@ main = defaultMain
     ++ Network.Haskoin.Transaction.Tests.tests
     ++ Network.Haskoin.Transaction.Units.tests
     ++ Network.Haskoin.Stratum.Units.tests
+    ++ Network.Haskoin.Json.Tests.tests
     )
 

--- a/tests/Network/Haskoin/Json/Tests.hs
+++ b/tests/Network/Haskoin/Json/Tests.hs
@@ -1,0 +1,32 @@
+module Network.Haskoin.Json.Tests (tests) where
+
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+
+import Data.Aeson
+
+import Network.Haskoin.Crypto
+import Network.Haskoin.Script
+import Network.Haskoin.Protocol
+import Network.Haskoin.Transaction
+import Network.Haskoin.Crypto.Arbitrary()
+import Network.Haskoin.Script.Arbitrary()
+import Network.Haskoin.Protocol.Arbitrary()
+import Network.Haskoin.Transaction.Arbitrary()
+
+
+tests :: [Test]
+tests = 
+    [ testGroup "Serialize & de-serialize haskoin types to JSON"
+        [ testProperty "Coin" (metaID :: Coin -> Bool)
+        , testProperty "ScriptOutput" (metaID :: ScriptOutput -> Bool)
+        , testProperty "OutPoint" (metaID :: OutPoint -> Bool)
+        , testProperty "Address" (metaID :: Address -> Bool)
+        , testProperty "Tx" (metaID :: Tx -> Bool)
+        , testProperty "TxHash" (metaID :: TxHash -> Bool)
+        , testProperty "Word256" (metaID :: Word256 -> Bool)
+        ]
+    ]
+
+metaID :: (FromJSON a, ToJSON a, Eq a) => a -> Bool
+metaID x = (decode . encode) [x] == Just [x]


### PR DESCRIPTION
This is a proposed change to compile haskoin against testnet using a cabal flag on installation:

```
cabal install --flags=testnet
```

However, the tests blow up if you compile against testnet. Can you help me have a look? We probably need to disable prodnet-only tests.
