### PR TITLE
Fix documentation error (extra space)

### DIFF
--- a/Network/Haskoin/Script/Types.hs
+++ b/Network/Haskoin/Script/Types.hs
@@ -506,7 +506,7 @@ instance Binary ScriptOp where
         OP_NOP10             -> putWord8 0xb9
 
 
- -- | Check whether opcode is only data.
+-- | Check whether opcode is only data.
 isPushOp :: ScriptOp -> Bool
 isPushOp op = case op of
     OP_PUSHDATA _ _ -> True


### PR DESCRIPTION
Haddock does not compile documentation because of this.
