### PR TITLE
Add Network.Haskoin.Internals to export haskoin internals

### DIFF
--- a/Network/Haskoin/Internals.hs
+++ b/Network/Haskoin/Internals.hs
@@ -1,0 +1,53 @@
+{-|
+  This module expose haskoin internals. No guarantee is made on the
+  stability of the interface of these internal modules.
+-}
+module Network.Haskoin.Internals
+( module Network.Haskoin.Crypto.NumberTheory
+, module Network.Haskoin.Crypto.Curve
+, module Network.Haskoin.Crypto.Hash
+, module Network.Haskoin.Crypto.BigWord
+, module Network.Haskoin.Crypto.Point
+, module Network.Haskoin.Crypto.Base58
+, module Network.Haskoin.Crypto.Keys
+, module Network.Haskoin.Crypto.ExtendedKeys
+, module Network.Haskoin.Crypto.NormalizedKeys
+, module Network.Haskoin.Crypto.ECDSA
+, module Network.Haskoin.Crypto.Mnemonic
+, module Network.Haskoin.Crypto.Merkle
+, module Network.Haskoin.Crypto.Bloom
+, module Network.Haskoin.Protocol.Message
+, module Network.Haskoin.Protocol.Types
+, module Network.Haskoin.Script.Types
+, module Network.Haskoin.Script.Parser
+, module Network.Haskoin.Script.SigHash
+, module Network.Haskoin.Script.Evaluator
+, module Network.Haskoin.Stratum.RPC
+, module Network.Haskoin.Stratum.Types
+, module Network.Haskoin.Stratum.Client
+, module Network.Haskoin.Transaction.Builder
+) where
+
+import Network.Haskoin.Crypto.NumberTheory
+import Network.Haskoin.Crypto.Curve
+import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Crypto.BigWord
+import Network.Haskoin.Crypto.Point
+import Network.Haskoin.Crypto.Base58
+import Network.Haskoin.Crypto.Keys
+import Network.Haskoin.Crypto.ExtendedKeys
+import Network.Haskoin.Crypto.NormalizedKeys
+import Network.Haskoin.Crypto.ECDSA
+import Network.Haskoin.Crypto.Mnemonic
+import Network.Haskoin.Crypto.Merkle
+import Network.Haskoin.Crypto.Bloom
+import Network.Haskoin.Protocol.Message
+import Network.Haskoin.Protocol.Types
+import Network.Haskoin.Script.Types
+import Network.Haskoin.Script.Parser
+import Network.Haskoin.Script.SigHash
+import Network.Haskoin.Script.Evaluator
+import Network.Haskoin.Stratum.RPC
+import Network.Haskoin.Stratum.Types
+import Network.Haskoin.Stratum.Client
+import Network.Haskoin.Transaction.Builder

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -34,6 +34,7 @@ library
                        Network.Haskoin.Protocol,
                        Network.Haskoin.Script,
                        Network.Haskoin.Transaction,
+                       Network.Haskoin.Internals,
                        Network.Haskoin.Constants
     other-modules:     Network.Haskoin.Crypto.NumberTheory, 
                        Network.Haskoin.Crypto.Curve, 


### PR DESCRIPTION
This enable libraries and tools to re-use the great code available here.
The rule is that no guarantee on the stability of such module.
