### PR TITLE
Fixed address/port stuff

### DIFF
--- a/Network/Haskoin/Protocol/Message.hs
+++ b/Network/Haskoin/Protocol/Message.hs
@@ -92,26 +92,7 @@ data Message
     | MPong !Pong 
     | MAlert !Alert
     | MReject Reject
-    deriving (Eq, Show, Read)
-
-instance NFData Message where
-    rnf (MVersion v) = rnf v
-    rnf (MAddr a) = rnf a
-    rnf (MInv i) = rnf i
-    rnf (MGetData d) = rnf d
-    rnf (MNotFound n) = rnf n
-    rnf (MGetBlocks b) = rnf b
-    rnf (MGetHeaders h) = rnf h
-    rnf (MTx t) = rnf t
-    rnf (MBlock b) = rnf b
-    rnf (MMerkleBlock b) = rnf b
-    rnf (MHeaders h) = rnf h
-    rnf (MFilterLoad f) = rnf f
-    rnf (MFilterAdd f) = rnf f
-    rnf (MPing p) = rnf p
-    rnf (MPong p) = rnf p
-    rnf (MAlert a) = rnf a
-    rnf x = x `seq` ()
+    deriving (Eq, Show)
 
 instance Binary Message where
 

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -69,6 +69,7 @@ library
                        either >= 4.3 && < 4.4,
                        json-rpc >= 0.2.0.1 && < 0.3,
                        mtl >= 2.1 && < 2.3, 
+                       network >= 2.6 && < 2.7,
                        pbkdf >= 1.1 && < 1.2,
                        split >= 0.2 && < 0.3,
                        text >= 1.1 && < 1.2
@@ -126,6 +127,7 @@ test-suite test-haskoin
                        either >= 4.3 && < 4.4,
                        json-rpc >= 0.2.0.1 && < 0.3,
                        mtl >= 2.1 && < 2.3, 
+                       network >= 2.6 && < 2.7,
                        pbkdf >= 1.1 && < 1.2,
                        split >= 0.2 && < 0.3,
                        text >= 1.1 && < 1.2,

--- a/tests/Network/Haskoin/Protocol/Arbitrary.hs
+++ b/tests/Network/Haskoin/Protocol/Arbitrary.hs
@@ -12,6 +12,8 @@ import Control.Applicative
 
 import qualified Data.Sequence as S (fromList)
 
+import Network.Socket
+
 import Network.Haskoin.Protocol
 import Network.Haskoin.Crypto
 
@@ -24,9 +26,15 @@ instance Arbitrary VarString where
 instance Arbitrary NetworkAddress where
     arbitrary = do
         s <- arbitrary
-        a <- liftM2 (,) arbitrary arbitrary
+        a <- arbitrary
+        b <- arbitrary
+        c <- arbitrary
+        d <- arbitrary
         p <- arbitrary
-        return $ NetworkAddress s a p
+        NetworkAddress s <$> elements
+            [ SockAddrInet6 (PortNum p) 0x00000000 (a,b,c,d) 0x00000000
+            , SockAddrInet (PortNum p) a
+            ]
 
 instance Arbitrary InvType where
     arbitrary = elements [InvError, InvTx, InvBlock, InvMerkleBlock]


### PR DESCRIPTION
Instead of using our own data types for IPv6-mapped IPv4 addresses, we are using standard SockAddr types from Network.Socket.  I have taken care of some weird endianness issues in types HostAddress and HostAddress6.
