### PR TITLE
HeaderChain

### DIFF
--- a/Network/Haskoin/Block.hs
+++ b/Network/Haskoin/Block.hs
@@ -15,7 +15,7 @@ module Network.Haskoin.Block
 , Headers(..)
 , BlockHeaderCount
 
-  -- *Merkle Blocks
+  -- * Merkle Blocks
 , MerkleBlock(..)
 , calcTreeHeight
 , calcTreeWidth
@@ -24,8 +24,34 @@ module Network.Haskoin.Block
 , buildPartialMerkle
 , extractMatches
 
+  -- * HeaderChain
+, BlockHeaderNode(..)
+, BlockHeaderStore(..)
+, BlockHeaderAction(..)
+, BlockChainAction(..)
+, initHeaderChain
+, connectBlockHeader
+, connectBlock
+, downloadBlockHeaders
+, blockLocator
+, lastSeenCheckpoint
+, findSplitNode
+, getParentNode
+, nextWorkRequired
+, workFromInterval
+, isValidPOW
+, headerPOW
+, headerWork
+
+  -- * Checkpoints
+, checkpointMap
+, checkpointList
+, verifyCheckpoint
+
 ) where
 
 import Network.Haskoin.Block.Types
 import Network.Haskoin.Block.Merkle
+import Network.Haskoin.Block.HeaderChain
+import Network.Haskoin.Block.Checkpoints
 

--- a/Network/Haskoin/Block.hs
+++ b/Network/Haskoin/Block.hs
@@ -29,11 +29,15 @@ module Network.Haskoin.Block
 , BlockHeaderStore(..)
 , BlockHeaderAction(..)
 , BlockChainAction(..)
+, getActionNode
 , initHeaderChain
 , connectBlockHeader
 , connectBlock
 , downloadBlockHeaders
 , blockLocator
+, rescanFrom
+, bestBlockHeaderHeight
+, bestBlockHeight
 , lastSeenCheckpoint
 , findSplitNode
 , getParentNode

--- a/Network/Haskoin/Block.hs
+++ b/Network/Haskoin/Block.hs
@@ -28,16 +28,12 @@ module Network.Haskoin.Block
 , BlockHeaderNode(..)
 , BlockHeaderStore(..)
 , BlockHeaderAction(..)
-, BlockChainAction(..)
-, getActionNode
+, genesisBlockHeaderNode
 , initHeaderChain
 , connectBlockHeader
-, connectBlock
-, downloadBlockHeaders
 , blockLocator
-, rescanFrom
 , bestBlockHeaderHeight
-, bestBlockHeight
+, getBlockHeaderHeight
 , lastSeenCheckpoint
 , findSplitNode
 , getParentNode
@@ -46,6 +42,11 @@ module Network.Haskoin.Block
 , isValidPOW
 , headerPOW
 , headerWork
+, BlockChainAction(..)
+, getActionNode
+, connectBlock
+, blocksToDownload
+, blockBeforeTimestamp
 
   -- * Checkpoints
 , checkpointMap

--- a/Network/Haskoin/Block/Checkpoints.hs
+++ b/Network/Haskoin/Block/Checkpoints.hs
@@ -1,0 +1,33 @@
+module Network.Haskoin.Block.Checkpoints 
+( checkpointMap
+, checkpointList
+, verifyCheckpoint
+) where
+
+import qualified Data.IntMap.Strict as M (IntMap, fromList, lookup)
+import qualified Data.ByteString as BS (reverse)
+
+import Network.Haskoin.Crypto
+import Network.Haskoin.Constants
+import Network.Haskoin.Util
+
+-- | Checkpoints from bitcoind reference implementation /src/checkpoints.cpp
+-- presented as an IntMap.
+checkpointMap :: M.IntMap BlockHash
+checkpointMap = M.fromList checkpointList
+
+-- | Checkpoints from bitcoind reference implementation /src/checkpoints.cpp
+-- presented as a list.
+checkpointList :: [(Int, BlockHash)]
+checkpointList = 
+    map (\(a,b) -> (a,rev (b :: BlockHash))) checkpoints
+  where
+    rev = decode' . BS.reverse . encode'
+
+-- | Verify that a block hash at a given height either matches an existing 
+-- checkpoint or is not a checkpoint. 
+verifyCheckpoint :: Int -> BlockHash -> Bool
+verifyCheckpoint height hash = case M.lookup height checkpointMap of
+    Just value -> hash == value
+    Nothing    -> True
+    

--- a/Network/Haskoin/Block/HeaderChain.hs
+++ b/Network/Haskoin/Block/HeaderChain.hs
@@ -1,0 +1,355 @@
+module Network.Haskoin.Block.HeaderChain 
+( BlockHeaderNode(..)
+, BlockHeaderStore(..)
+, BlockHeaderAction(..)
+, BlockChainAction(..)
+, genesisBlockHeaderNode
+, initHeaderChain
+, connectBlockHeader
+, connectBlock
+, downloadBlockHeaders
+, blockLocator
+, lastSeenCheckpoint
+, findSplitNode
+, getParentNode
+, nextWorkRequired
+, workFromInterval
+, isValidPOW
+, headerPOW
+, headerWork
+)
+where
+
+import Control.Monad (foldM, when, unless, liftM)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Either (left, runEitherT)
+
+import Data.Word (Word32)
+import Data.Bits (shiftL)
+import Data.Maybe (fromJust, isNothing)
+import Data.List (sort, nub)
+import qualified Data.ByteString as BS (reverse)
+
+import Network.Haskoin.Block.Types
+import Network.Haskoin.Block.Checkpoints
+import Network.Haskoin.Crypto
+import Network.Haskoin.Constants
+import Network.Haskoin.Util
+
+-- | Data type representing a BlockHeader node in the header chain. It
+-- contains additional data such as the chain work and chain height for this
+-- node.
+data BlockHeaderNode = BlockHeaderNode 
+    { nodeBlockHash    :: !BlockHash
+    , nodeHeader       :: !BlockHeader
+    , nodeHeaderHeight :: !Word32
+    , nodeChainWork    :: !Integer
+    , nodeChild        :: !(Maybe BlockHash)
+    , nodeMedianTimes  :: ![Word32]
+    , nodeMinWork      :: !Word32 -- Only used for testnet
+    } deriving (Show, Read, Eq)
+
+-- Return value of linking a new block header in the chain
+-- TODO: Add more options if required
+data BlockHeaderAction
+    = RejectHeader String
+    | HeaderAlreadyExists BlockHeaderNode
+    | AcceptHeader BlockHeaderNode
+    deriving (Show, Read, Eq)
+
+data BlockChainAction
+    = BestBlock  { actionBestBlock :: BlockHeaderNode }
+    | SideBlock  { actionSideBlock :: BlockHeaderNode }
+    | BlockReorg { reorgSplitPoint :: BlockHeaderNode
+                 , reorgOldBlocks  :: [BlockHeaderNode]
+                 , reorgNewBlocks  :: [BlockHeaderNode]
+                 }
+    deriving (Read, Show, Eq)
+
+class Monad m => BlockHeaderStore m where
+    getBlockHeaderNode    :: BlockHash -> m BlockHeaderNode
+    putBlockHeaderNode    :: BlockHeaderNode -> m ()
+    existsBlockHeaderNode :: BlockHash -> m Bool
+    getBestBlockHeader    :: m BlockHeaderNode
+    setBestBlockHeader    :: BlockHeaderNode -> m ()
+    getBestBlock          :: m BlockHeaderNode
+    setBestBlock          :: BlockHeaderNode -> m ()
+    getLastDownload       :: m BlockHeaderNode
+    setLastDownload       :: BlockHeaderNode -> m ()
+
+-- | Number of blocks on average between difficulty cycles (2016 blocks)
+diffInterval :: Word32
+diffInterval = targetTimespan `div` targetSpacing
+
+-- | Genesis BlockHeaderNode
+genesisBlockHeaderNode :: BlockHeaderNode
+genesisBlockHeaderNode = BlockHeaderNode
+    { nodeBlockHash    = headerHash genesisHeader
+    , nodeHeader       = genesisHeader
+    , nodeHeaderHeight = 0
+    , nodeChainWork    = headerWork genesisHeader
+    , nodeChild        = Nothing
+    , nodeMedianTimes  = [blockTimestamp genesisHeader]
+    , nodeMinWork      = blockBits genesisHeader
+    }
+
+-- | Initialize the block header chain by inserting the genesis block if
+-- it doesn't already exist.
+initHeaderChain :: BlockHeaderStore m => m ()
+initHeaderChain = do
+    existsGen <- existsBlockHeaderNode $ nodeBlockHash genesisBlockHeaderNode
+    unless existsGen $ do
+        putBlockHeaderNode genesisBlockHeaderNode
+        setBestBlockHeader genesisBlockHeaderNode
+        setBestBlock       genesisBlockHeaderNode
+        setLastDownload    genesisBlockHeaderNode
+
+-- TODO: Add DOS return values
+-- | Connect a block header to this block header chain. Corresponds to bitcoind
+-- function ProcessBlockHeader and AcceptBlockHeader in main.cpp.
+connectBlockHeader :: BlockHeaderStore m 
+                   => BlockHeader 
+                   -> Word32 
+                   -> Word32
+                   -> m BlockHeaderAction
+connectBlockHeader bh adjustedTime fastCatchup = ((liftM f) . runEitherT) $ do
+    unless (isValidPOW bh) $ 
+        left $ RejectHeader "Invalid proof of work"
+    unless (blockTimestamp bh <= adjustedTime + 2 * 60 * 60) $
+        left $ RejectHeader "Invalid header timestamp"
+    blockExists <- lift $ existsBlockHeaderNode bid
+    when blockExists $ do
+        prev <- lift $ getBlockHeaderNode bid
+        left $ HeaderAlreadyExists prev
+    prevExists <- lift $ existsBlockHeaderNode $ prevBlock bh
+    unless prevExists $ left $ RejectHeader "Previous block not found"
+    prevNode <- lift $ getBlockHeaderNode $ prevBlock bh
+    nextWork <- lift $ nextWorkRequired prevNode bh
+    unless (blockBits bh == nextWork) $
+        left $ RejectHeader "Incorrect work transition (bits)"
+    let sortedMedians = sort $ nodeMedianTimes prevNode
+        medianTime    = sortedMedians !! (length sortedMedians `div` 2)
+    when (blockTimestamp bh <= medianTime) $
+        left $ RejectHeader "Block timestamp is too early"
+    chkPointM <- lift lastSeenCheckpoint
+    let chkPoint  = fromJust chkPointM
+        newHeight = nodeHeaderHeight prevNode + 1
+    unless (isNothing chkPointM || (fromIntegral newHeight) > fst chkPoint) $
+        left $ RejectHeader "Rewriting pre-checkpoint chain"
+    unless (verifyCheckpoint (fromIntegral newHeight) bid) $
+        left $ RejectHeader "Rejected by checkpoint lock-in"
+    -- All block of height 227836 or more use version 2 in prodnet
+    -- TODO: Find out the value here for testnet
+    when (  networkName == "prodnet" 
+         && blockVersion bh == 1 
+         && nodeHeaderHeight prevNode + 1 >= 227836) $
+        left $ RejectHeader "Rejected version=1 block"
+    lift $ storeBlockHeader prevNode bh fastCatchup
+  where
+    f (Right x) = x
+    f (Left  x) = x
+    bid = headerHash bh
+
+storeBlockHeader :: BlockHeaderStore m 
+                 => BlockHeaderNode 
+                 -> BlockHeader 
+                 -> Word32
+                 -> m BlockHeaderAction
+storeBlockHeader prevNode bh fastCatchup = do
+    putBlockHeaderNode newNode
+    putBlockHeaderNode $ prevNode{ nodeChild = Just bid }
+    currentHead <- getBestBlockHeader
+    when (newWork > nodeChainWork currentHead) $ do
+        setBestBlockHeader newNode
+        -- Update the block head if we are before the fast catchup time
+        -- By setting a new best block, we sort of flag it as downloaded
+        when (blockTimestamp bh < fastCatchup) $ do
+            setBestBlock newNode
+            setLastDownload newNode
+    return $ AcceptHeader newNode
+  where
+    bid       = headerHash bh
+    newHeight = nodeHeaderHeight prevNode + 1
+    newWork   = nodeChainWork prevNode + headerWork bh
+    newMedian 
+        | length (nodeMedianTimes prevNode) == 11 =
+            tail (nodeMedianTimes prevNode) ++ [blockTimestamp bh]
+        | otherwise = (nodeMedianTimes prevNode) ++ [blockTimestamp bh]
+    isDiffChange = newHeight `mod` diffInterval == 0
+    isNotLimit   = blockBits bh /= encodeCompact powLimit
+    minWork | not allowMinDifficultyBlocks = 0
+            | isDiffChange || isNotLimit   = blockBits bh
+            | otherwise                    = nodeMinWork prevNode
+    newNode = BlockHeaderNode { nodeBlockHash    = bid
+                              , nodeHeader       = bh
+                              , nodeHeaderHeight = newHeight
+                              , nodeChainWork    = newWork
+                              , nodeChild        = Nothing
+                              , nodeMedianTimes  = newMedian
+                              , nodeMinWork      = minWork
+                              }
+
+-- | Returns a list of BlockHash that needs to be downloaded.
+downloadBlockHeaders :: BlockHeaderStore m => Int -> m [BlockHash]
+downloadBlockHeaders count = do
+    n <- getLastDownload
+    (res, lstDwn) <- go [] count n
+    setLastDownload lstDwn
+    return $ reverse res
+  where
+    go acc step n
+        | step == 0 = return (acc, n)
+        | isNothing $ nodeChild n = do
+            bestHead <- getBestBlockHeader
+            -- The pointer could be stuck in an orphaned fork
+            if nodeChainWork bestHead > nodeChainWork n
+                then do
+                    (split,_,_) <- findSplitNode bestHead n
+                    go ((nodeBlockHash split):acc) (step-1) split
+                else return (acc, n)
+        | otherwise = do
+            c <- getBlockHeaderNode $ fromJust $ nodeChild n
+            go ((nodeBlockHash c):acc) (step-1) c 
+
+-- | Connect a block to blockchain. Blocks need to be imported in the order
+-- of the parent links (oldest to newest).
+connectBlock :: BlockHeaderStore m => BlockHeader -> m BlockChainAction
+connectBlock bh = do
+    newNode   <- getBlockHeaderNode bid
+    bestBlock <- getBestBlock
+    if prevBlock (nodeHeader newNode) == nodeBlockHash bestBlock
+        -- We connect to the best chain
+        then do
+            setBestBlock newNode
+            return $ BestBlock newNode
+        else if nodeChainWork newNode > nodeChainWork bestBlock
+                 then handleNewBestChain newNode bestBlock
+                 else return $ SideBlock newNode
+  where
+    bid = headerHash bh
+
+handleNewBestChain :: BlockHeaderStore m 
+                   => BlockHeaderNode -> BlockHeaderNode -> m BlockChainAction
+handleNewBestChain newChainHead oldChainHead = do
+    (splitPoint, oldChain, newChain) <- findSplitNode oldChainHead newChainHead
+    setBestBlock newChainHead
+    return $ BlockReorg splitPoint oldChain newChain
+
+-- | Get the last checkpoint that we have seen
+lastSeenCheckpoint :: BlockHeaderStore m => m (Maybe (Int, BlockHash))
+lastSeenCheckpoint = 
+    foldM f Nothing $ reverse checkpointList
+  where
+    f res@(Just _) _  = return res
+    f Nothing (i,chk) = do
+        existsChk <- existsBlockHeaderNode chk
+        return $ if existsChk then Just (i,chk) else Nothing
+
+-- | Find the split point between two nodes. It also returns the two partial
+-- chains leading from the split point to the respective nodes.
+findSplitNode :: BlockHeaderStore m => BlockHeaderNode -> BlockHeaderNode
+              -> m (BlockHeaderNode, [BlockHeaderNode], [BlockHeaderNode])
+findSplitNode n1 n2 = go [] [] n1 n2
+  where
+    go xs ys x y
+        | nodeBlockHash x == nodeBlockHash y = return (x, x:xs, y:ys)
+        | nodeHeaderHeight x > nodeHeaderHeight y = do
+            par <- getParentNode x
+            go (x:xs) ys par y
+        | otherwise = do
+            par <- getParentNode y
+            go xs (y:ys) x par
+
+-- | Finds the parent of a BlockHeaderNode. Returns an error if a parent
+-- node doesn't exist (for example, the genesis block).
+getParentNode :: BlockHeaderStore m => BlockHeaderNode -> m BlockHeaderNode
+getParentNode node 
+    | p == 0    = error "Genesis block has no parent"
+    | otherwise = getBlockHeaderNode p
+  where
+    p = prevBlock $ nodeHeader node
+
+-- | Returns the work required for a BlockHeader given the previous
+-- BlockHeaderNode. This function coresponds to bitcoind function
+-- GetNextWorkRequired in main.cpp.
+nextWorkRequired :: BlockHeaderStore m 
+                 => BlockHeaderNode -> BlockHeader -> m Word32
+nextWorkRequired lastNode bh
+    -- Genesis block
+    | prevBlock (nodeHeader lastNode) == 0 = return $ encodeCompact powLimit
+    -- Only change the difficulty once per interval
+    | (nodeHeaderHeight lastNode + 1) `mod` diffInterval /= 0 = return $
+        if allowMinDifficultyBlocks 
+            then minPOW 
+            else blockBits $ nodeHeader lastNode
+    | otherwise = do
+        -- TODO: Can this break if there are not enough blocks in the chain?
+        firstNode <- foldM (\x f -> f x) lastNode fs
+        let lastTs = blockTimestamp $ nodeHeader firstNode
+        return $ workFromInterval lastTs (nodeHeader lastNode)
+  where
+    fs    = replicate (fromIntegral diffInterval - 1) getParentNode
+    delta = targetSpacing * 2
+    minPOW
+        | blockTimestamp bh > (blockTimestamp $ nodeHeader lastNode) + delta =
+            encodeCompact powLimit
+        | otherwise = nodeMinWork lastNode
+
+-- | Computes the work required for the next block given a timestamp and the
+-- current block. The timestamp should come from the block that matched the
+-- last jump in difficulty (spaced out by 2016 blocks in prodnet).
+workFromInterval :: Word32 -> BlockHeader -> Word32
+workFromInterval ts lastB
+    | newDiff > powLimit = encodeCompact powLimit
+    | otherwise          = encodeCompact newDiff
+  where
+    t = fromIntegral $ (blockTimestamp lastB) - ts
+    actualTime 
+        | t < targetTimespan `div` 4 = targetTimespan `div` 4
+        | t > targetTimespan * 4     = targetTimespan * 4
+        | otherwise                  = t
+    lastDiff = decodeCompact $ blockBits lastB
+    newDiff = lastDiff * (toInteger actualTime) `div` (toInteger targetTimespan)
+
+-- | Returns a BlockLocator object.
+blockLocator :: BlockHeaderStore m => m BlockLocator
+blockLocator = do
+    h  <- getBestBlockHeader
+    let xs = [go ((2 :: Int)^x) | x <- ([0..] :: [Int])]
+    ns <- f [h] $ replicate 10 (go (1 :: Int)) ++ xs
+    return $ reverse $ nub $ genid : map nodeBlockHash ns
+  where
+    genid = headerHash genesisHeader
+    f acc gs = (head gs) (head acc) >>= \resM -> case resM of
+        Just res -> f (res:acc) (tail gs)
+        Nothing  -> return acc
+    go step n 
+        | prevBlock (nodeHeader n) == 0 = return Nothing
+        | step == 0 = return $ Just n
+        | otherwise = go (step - 1) =<< getParentNode n
+
+-- | Returns True if the difficulty target (bits) of the header is valid
+-- and the proof of work of the header matches the advertised difficulty target.
+-- This function corresponds to the function CheckProofOfWork from bitcoind
+-- in main.cpp
+isValidPOW :: BlockHeader -> Bool
+isValidPOW bh
+    | target <= 0 || target > powLimit = False
+    | otherwise = headerPOW bh <= fromIntegral target
+  where
+    target = decodeCompact $ blockBits bh
+
+-- | Returns the proof of work of a block header as an Integer number.
+headerPOW :: BlockHeader -> Integer
+headerPOW =  bsToInteger . BS.reverse . encode' . headerHash
+
+-- | Returns the work represented by this block. Work is defined as the number 
+-- of tries needed to solve a block in the average case with respect to the
+-- target.
+headerWork :: BlockHeader -> Integer
+headerWork bh = 
+    largestHash `div` (target + 1)
+  where
+    target      = decodeCompact (blockBits bh)
+    largestHash = 1 `shiftL` 256
+

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -62,6 +62,8 @@ library
                        Network.Haskoin.Transaction.Builder,
                        Network.Haskoin.Block.Types,
                        Network.Haskoin.Block.Merkle,
+                       Network.Haskoin.Block.HeaderChain,
+                       Network.Haskoin.Block.Checkpoints,
                        Network.Haskoin.Test.Crypto,
                        Network.Haskoin.Test.Node,
                        Network.Haskoin.Test.Message,

--- a/prodnet/Network/Haskoin/Constants.hs
+++ b/prodnet/Network/Haskoin/Constants.hs
@@ -3,6 +3,7 @@
 -}
 module Network.Haskoin.Constants where
 
+import Data.Bits (shiftR)
 import Data.Word (Word8, Word32, Word64)
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Block.Types
@@ -68,6 +69,18 @@ defaultPort = 8333
 -- for testnet.
 allowMinDifficultyBlocks :: Bool
 allowMinDifficultyBlocks = False
+
+-- | Lower bound for the proof of work difficulty
+powLimit :: Integer
+powLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+
+-- | Time between difficulty cycles (2 weeks on average)
+targetTimespan :: Word32
+targetTimespan = 14 * 24 * 60 * 60
+
+-- | Time between blocks (10 minutes per block)
+targetSpacing :: Word32
+targetSpacing = 10 * 60
 
 -- | Checkpoints to enfore
 checkpoints :: [(Int, BlockHash)]

--- a/testnet/Network/Haskoin/Constants.hs
+++ b/testnet/Network/Haskoin/Constants.hs
@@ -3,6 +3,7 @@
 -}
 module Network.Haskoin.Constants where
 
+import Data.Bits (shiftR)
 import Data.Word (Word8, Word32, Word64)
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Block.Types
@@ -68,6 +69,18 @@ defaultPort = 18333
 -- for testnet.
 allowMinDifficultyBlocks :: Bool
 allowMinDifficultyBlocks = True
+
+-- | Lower bound for the proof of work difficulty
+powLimit :: Integer
+powLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+
+-- | Time between difficulty cycles (2 weeks on average)
+targetTimespan :: Word32
+targetTimespan = 14 * 24 * 60 * 60
+
+-- | Time between blocks (10 minutes per block)
+targetSpacing :: Word32
+targetSpacing = 10 * 60
 
 -- | Checkpoints to enfore
 checkpoints :: [(Int, BlockHash)]


### PR DESCRIPTION
This patch adds a HeaderChain implementation to Haskoin. It is a headers-first chain implementation with optional fast catchup. It can validate the proof of work of block headers and is meant to be used together with an SPV client.
