### PR TITLE
Adding distinct types for compressed and uncompressed keys

### DIFF
--- a/Network/Haskoin/Crypto.hs
+++ b/Network/Haskoin/Crypto.hs
@@ -8,24 +8,37 @@ module Network.Haskoin.Crypto
   -- *Elliptic Curve Keys
   
   -- **Public Keys
-  PubKey(..)
+  PubKey, PubKeyC, PubKeyU
+, makePubKey
+, makePubKeyG
+, makePubKeyC
+, makePubKeyU
+, toPubKeyG
+, eitherPubKey
+, maybePubKeyC
+, maybePubKeyU
 , isValidPubKey
-, isPubKeyU
 , derivePubKey
 , pubKeyAddr
 
   -- **Private Keys
-, PrvKey(..)
-, isValidPrvKey
+, PrvKey, PrvKeyC, PrvKeyU
 , makePrvKey
+, makePrvKeyG
+, makePrvKeyC
 , makePrvKeyU
+, toPrvKeyG
+, eitherPrvKey
+, maybePrvKeyC
+, maybePrvKeyU
+, isValidPrvKey
 , fromPrvKey
-, isPrvKeyU
-, putPrvKey
-, getPrvKey
-, getPrvKeyU
-, fromWIF
-, toWIF
+, encodePrvKey
+, decodePrvKey
+, prvKeyPutMonad
+, prvKeyGetMonad
+, fromWif
+, toWif
 
   -- *ECDSA
   -- **SecretT Monad
@@ -119,7 +132,7 @@ module Network.Haskoin.Crypto
 , xPrvFP
 , xPrvExport
 , xPrvImport
-, xPrvWIF
+, xPrvWif
 
   -- **Extended Public Keys
 , XPubKey(..)

--- a/Network/Haskoin/Crypto/NormalizedKeys.hs
+++ b/Network/Haskoin/Crypto/NormalizedKeys.hs
@@ -46,6 +46,7 @@ import Data.Word (Word32)
 import Data.Maybe (mapMaybe, fromJust, isJust)
 import qualified Data.ByteString as BS (ByteString)
 
+import Network.Haskoin.Crypto.Keys
 import Network.Haskoin.Crypto.ExtendedKeys
 import Network.Haskoin.Crypto.Base58
 import Network.Haskoin.Script.Parser
@@ -281,14 +282,14 @@ intMulSigKeys a ps i = mapMaybe f $ cycleIndex i
 extMulSigAddr :: AccPubKey -> [XPubKey] -> Int -> KeyIndex -> Maybe Address
 extMulSigAddr a ps r i = do
     xs <- (map (xPubKey . getAddrPubKey)) <$> extMulSigKey a ps i
-    return $ scriptAddr $ sortMulSig $ PayMulSig xs r
+    return $ scriptAddr $ sortMulSig $ PayMulSig (map toPubKeyG xs) r
 
 -- | Computes an internal multisig address from an 'AccPubKey', a
 -- list of thirdparty multisig keys and a derivation index.
 intMulSigAddr :: AccPubKey -> [XPubKey] -> Int -> KeyIndex -> Maybe Address
 intMulSigAddr a ps r i = do
     xs <- (map (xPubKey . getAddrPubKey)) <$> intMulSigKey a ps i
-    return $ scriptAddr $ sortMulSig $ PayMulSig xs r
+    return $ scriptAddr $ sortMulSig $ PayMulSig (map toPubKeyG xs) r
 
 -- | Cyclic list of all external multisig addresses derived from
 -- an 'AccPubKey' and a list of thirdparty multisig keys. The list starts

--- a/Network/Haskoin/Test/Crypto.hs
+++ b/Network/Haskoin/Test/Crypto.hs
@@ -75,21 +75,21 @@ newtype ArbitraryPrvKey = ArbitraryPrvKey PrvKey
 
 instance Arbitrary ArbitraryPrvKey where
     arbitrary = ArbitraryPrvKey <$> oneof 
-        [ arbitrary >>= \(ArbitraryPrvKeyC k) -> return k
-        , arbitrary >>= \(ArbitraryPrvKeyU k) -> return k
+        [ arbitrary >>= \(ArbitraryPrvKeyC k) -> return (toPrvKeyG k)
+        , arbitrary >>= \(ArbitraryPrvKeyU k) -> return (toPrvKeyG k)
         ]
 
 -- | Arbitrary compressed private key
-newtype ArbitraryPrvKeyC = ArbitraryPrvKeyC PrvKey
+newtype ArbitraryPrvKeyC = ArbitraryPrvKeyC PrvKeyC
     deriving (Eq, Show, Read)
 
 instance Arbitrary ArbitraryPrvKeyC where
     arbitrary = do
         i <- fromInteger <$> choose (1, curveN-1)
-        return $ ArbitraryPrvKeyC $ fromJust $ makePrvKey i
+        return $ ArbitraryPrvKeyC $ fromJust $ makePrvKeyC i
         
 -- | Arbitrary uncompressed private key
-newtype ArbitraryPrvKeyU = ArbitraryPrvKeyU PrvKey
+newtype ArbitraryPrvKeyU = ArbitraryPrvKeyU PrvKeyU
     deriving (Eq, Show, Read)
 
 instance Arbitrary ArbitraryPrvKeyU where
@@ -104,12 +104,14 @@ data ArbitraryPubKey = ArbitraryPubKey PrvKey PubKey
 
 instance Arbitrary ArbitraryPubKey where
     arbitrary = oneof
-        [ arbitrary >>= \(ArbitraryPubKeyC k p) -> return $ ArbitraryPubKey k p
-        , arbitrary >>= \(ArbitraryPubKeyU k p) -> return $ ArbitraryPubKey k p
+        [ arbitrary >>= \(ArbitraryPubKeyC k p) -> 
+            return $ ArbitraryPubKey (toPrvKeyG k) (toPubKeyG p)
+        , arbitrary >>= \(ArbitraryPubKeyU k p) -> 
+            return $ ArbitraryPubKey (toPrvKeyG k) (toPubKeyG p)
         ]
 
 -- | Arbitrary compressed public key with its corresponding private key.
-data ArbitraryPubKeyC = ArbitraryPubKeyC PrvKey PubKey
+data ArbitraryPubKeyC = ArbitraryPubKeyC PrvKeyC PubKeyC
     deriving (Eq, Show, Read)
 
 instance Arbitrary ArbitraryPubKeyC where
@@ -118,7 +120,7 @@ instance Arbitrary ArbitraryPubKeyC where
         return $ ArbitraryPubKeyC k $ derivePubKey k
 
 -- | Arbitrary uncompressed public key with its corresponding private key.
-data ArbitraryPubKeyU = ArbitraryPubKeyU PrvKey PubKey
+data ArbitraryPubKeyU = ArbitraryPubKeyU PrvKeyU PubKeyU
     deriving (Eq, Show, Read)
 
 instance Arbitrary ArbitraryPubKeyU where

--- a/Network/Haskoin/Test/Script.hs
+++ b/Network/Haskoin/Test/Script.hs
@@ -325,7 +325,7 @@ instance Arbitrary ArbitraryMSCOutput where
         keys <- map f <$> vectorOf n arbitrary
         return $ ArbitraryMSCOutput $ PayMulSig keys m
       where
-        f (ArbitraryPubKeyC _ key) = key
+        f (ArbitraryPubKeyC _ key) = toPubKeyG key
 
 -- | Arbitrary ScriptOutput of type PayScriptHash
 newtype ArbitrarySHOutput = ArbitrarySHOutput ScriptOutput
@@ -394,7 +394,8 @@ instance Arbitrary ArbitraryPKHashCInput where
             , arbitrary >>= \(ArbitraryDetTxSignature _ _ sig) -> return sig
             ]
         ArbitraryPubKeyC _ key <- arbitrary
-        return $ ArbitraryPKHashCInput $ RegularInput $ SpendPKHash sig key
+        return $ ArbitraryPKHashCInput $ RegularInput $ 
+            SpendPKHash sig $ toPubKeyG key
 
 -- | Arbitrary ScriptInput of type SpendMulSig
 newtype ArbitraryMSInput = ArbitraryMSInput ScriptInput

--- a/tests/Network/Haskoin/Crypto/ExtendedKeys/Units.hs
+++ b/tests/Network/Haskoin/Crypto/ExtendedKeys/Units.hs
@@ -153,8 +153,8 @@ runXKeyVec (v,m) = do
     assertBool "xPrvFP" $ (bsToHex $ encode' $ xPrvFP m) == v !! 1
     assertBool "xPrvAddr" $ 
         (addrToBase58 $ xPubAddr $ deriveXPubKey m) == v !! 2
-    assertBool "prvKey" $ (bsToHex $ runPut' $ putPrvKey $ xPrvKey m) == v !! 3
-    assertBool "xPrvWIF" $ xPrvWIF m == v !! 4
+    assertBool "prvKey" $ (bsToHex $ encodePrvKey $ xPrvKey m) == v !! 3
+    assertBool "xPrvWIF" $ xPrvWif m == v !! 4
     assertBool "pubKey" $ 
         (bsToHex $ encode' $ xPubKey $ deriveXPubKey m) == v !! 5
     assertBool "chain code" $ (bsToHex $ encode' $ xPrvChain m) == v !! 6

--- a/tests/Network/Haskoin/Crypto/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Units.hs
@@ -54,16 +54,16 @@ sigMsg = [ ("Very secret message " ++ (show (i :: Int)) ++ ": 11")
          ]
 
 sec1 :: PrvKey
-sec1  = fromJust $ fromWIF strSecret1
+sec1  = fromJust $ fromWif strSecret1
 
 sec2 :: PrvKey
-sec2  = fromJust $ fromWIF strSecret2
+sec2  = fromJust $ fromWif strSecret2
 
 sec1C :: PrvKey
-sec1C = fromJust $ fromWIF strSecret1C
+sec1C = fromJust $ fromWif strSecret1C
 
 sec2C :: PrvKey
-sec2C = fromJust $ fromWIF strSecret2C
+sec2C = fromJust $ fromWif strSecret2C
 
 pub1 :: PubKey
 pub1  = derivePubKey sec1
@@ -138,29 +138,28 @@ uniqueKeys = do
 
 checkPrivkey :: Assertion
 checkPrivkey = do
-    assertBool "Key 1"  $ isJust $ fromWIF strSecret1
-    assertBool "Key 2"  $ isJust $ fromWIF strSecret2
-    assertBool "Key 1C" $ isJust $ fromWIF strSecret1C
-    assertBool "Key 2C" $ isJust $ fromWIF strSecret2C
+    assertBool "Key 1"  $ isJust $ fromWif strSecret1
+    assertBool "Key 2"  $ isJust $ fromWif strSecret2
+    assertBool "Key 1C" $ isJust $ fromWif strSecret1C
+    assertBool "Key 2C" $ isJust $ fromWif strSecret2C
 
 checkInvalidKey :: Assertion
 checkInvalidKey = 
-    assertBool "Bad key" $ isNothing $ fromWIF strAddressBad
-
+    assertBool "Bad key" $ isNothing $ fromWif strAddressBad
 
 checkPrvKeyCompressed :: Assertion
 checkPrvKeyCompressed = do
-    assertBool "Key 1"  $ isPrvKeyU sec1
-    assertBool "Key 2"  $ isPrvKeyU sec2
-    assertBool "Key 1C" $ not $ isPrvKeyU sec1C
-    assertBool "Key 2C" $ not $ isPrvKeyU sec2C
+    assertBool "Key 1"  $ not $ prvKeyCompressed sec1
+    assertBool "Key 2"  $ not $ prvKeyCompressed sec2
+    assertBool "Key 1C" $ prvKeyCompressed sec1C
+    assertBool "Key 2C" $ prvKeyCompressed sec2C
 
 checkKeyCompressed :: Assertion
 checkKeyCompressed = do
-    assertBool "Key 1"  $ isPubKeyU pub1
-    assertBool "Key 2"  $ isPubKeyU pub2
-    assertBool "Key 1C" $ not $ isPubKeyU pub1C
-    assertBool "Key 2C" $ not $ isPubKeyU pub2C
+    assertBool "Key 1"  $ not $ pubKeyCompressed pub1
+    assertBool "Key 2"  $ not $ pubKeyCompressed pub2
+    assertBool "Key 1C" $ pubKeyCompressed pub1C
+    assertBool "Key 2C" $ pubKeyCompressed pub2C
 
 checkMatchingAddress :: Assertion
 checkMatchingAddress = do

--- a/tests/Network/Haskoin/Node/Units.hs
+++ b/tests/Network/Haskoin/Node/Units.hs
@@ -66,7 +66,7 @@ bloomFilter3 = do
     f0 = bloomCreate 2 0.001 0 BloomUpdateAll
     f1 = bloomInsert f0 $ encode' p
     f2 = bloomInsert f1 $ encode' $ getAddrHash $ pubKeyAddr p
-    k = fromJust $ fromWIF "5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"
+    k = fromJust $ fromWif "5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"
     p = derivePubKey k
     bs = fromJust $ hexToBS "038fc16b080000000000000001"
 


### PR DESCRIPTION
I use an internal phantom type (PubKeyI c) with hidden data constructors. The phantom parameter can be Generic, Compressed or Uncompressed. By default, Generic is used and the compression is tracked as data inside the type. However, you can use Compressed or Uncompressed to have distinct types for each case.

Type aliases are provided for convenience:

``` haskell
type PubKey = PubKeyI Generic
type PubKeyC = PubKeyI Compressed
type PubKeyU = PubKeyI Uncompressed
```

The same pattern is used for private keys.

The advantage of this method is to expose specific compressed and uncompressed types where needed (ex: only compressed keys are allowed in extended bip32 keys) while retaining the generic behavior everywhere else where compression doesn't matter and where you need homogeneous lists of keys that can be both compressed or uncompressed. The solution remains simple and non-invasive: there are no phantom parameters leaking all over the library. Using phantom types also simplifies the library as high-level functions that apply to any key type can be easily defined without having to create specialized versions for each compression type.
