### PR TITLE
Adds aeson instances for Fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 0.21.0
 ### Changed
-- Use a newtype for Fingerprint, which uses an 8 digit hex string for IsString,
-  Read, & Show.  This fixes inconsistent (de)serialization across the package.
+- Use a newtype for Fingerprint, which uses an 8 digit hex string for various
+  instances.  This fixes inconsistent (de)serialization across the package.
 
 ### Fixed
 - Makes `finalScriptWitness` field encoding conform to bitcoin core.

--- a/src/Haskoin/Keys/Extended.hs
+++ b/src/Haskoin/Keys/Extended.hs
@@ -21,6 +21,8 @@ module Haskoin.Keys.Extended
     , ChainCode
     , KeyIndex
     , Fingerprint
+    , fingerprintToText
+    , textToFingerprint
     , DerivationException(..)
     , makeXPrvKey
     , deriveXPubKey
@@ -135,7 +137,9 @@ import           Haskoin.Address
 import           Haskoin.Constants
 import           Haskoin.Crypto.Hash
 import           Haskoin.Keys.Common
-import           Haskoin.Keys.Extended.Internal (Fingerprint (..))
+import           Haskoin.Keys.Extended.Internal (Fingerprint (..),
+                                                 fingerprintToText,
+                                                 textToFingerprint)
 import           Haskoin.Script
 import           Haskoin.Util
 import           Text.Read                      as R


### PR DESCRIPTION
Represent `Fingerprint` as an 8-digit hex string in JSON representations.